### PR TITLE
fix(border-radius): add semantic border radius tokens

### DIFF
--- a/packages/styles/_generated/base/_semantic.scss
+++ b/packages/styles/_generated/base/_semantic.scss
@@ -163,6 +163,9 @@
   --pine-border: var(--pine-border-width-thin) solid var(--pine-color-grey-300);
   --pine-border-hover: var(--pine-border-width-thin) solid var(--pine-color-grey-400);
   --pine-border-none: var(--pine-border-width-none) solid var(--pine-color-grey-300);
+  --pine-border-radius-sm: var(--pine-dimension-050);
+  --pine-border-radius-md: var(--pine-dimension-125);
+  --pine-border-radius-lg: var(--pine-dimension-200);
   --pine-border-radius-full: 9999px;
   --pine-typography-heading-1: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-1)/var(--pine-line-height-heading) var(--pine-font-family-greet);
   --pine-typography-heading-2: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-2)/var(--pine-line-height-heading) var(--pine-font-family-greet);

--- a/packages/styles/_generated/kajabi_products/kajabi_products.scss
+++ b/packages/styles/_generated/kajabi_products/kajabi_products.scss
@@ -424,6 +424,9 @@
   --pine-border: var(--pine-border-width-thin) solid var(--pine-color-grey-300);
   --pine-border-hover: var(--pine-border-width-thin) solid var(--pine-color-grey-400);
   --pine-border-none: var(--pine-border-width-none) solid var(--pine-color-grey-300);
+  --pine-border-radius-sm: var(--pine-dimension-050);
+  --pine-border-radius-md: var(--pine-dimension-125);
+  --pine-border-radius-lg: var(--pine-dimension-200);
   --pine-border-radius-full: 9999px;
   --pine-typography-heading-1: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-1)/var(--pine-line-height-heading) var(--pine-font-family-greet);
   --pine-typography-heading-2: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-2)/var(--pine-line-height-heading) var(--pine-font-family-greet);

--- a/packages/styles/_generated/pine/pine.scss
+++ b/packages/styles/_generated/pine/pine.scss
@@ -424,6 +424,9 @@
   --pine-border: var(--pine-border-width-thin) solid var(--pine-color-grey-300);
   --pine-border-hover: var(--pine-border-width-thin) solid var(--pine-color-grey-400);
   --pine-border-none: var(--pine-border-width-none) solid var(--pine-color-grey-300);
+  --pine-border-radius-sm: var(--pine-dimension-050);
+  --pine-border-radius-md: var(--pine-dimension-125);
+  --pine-border-radius-lg: var(--pine-dimension-200);
   --pine-border-radius-full: 9999px;
   --pine-typography-heading-1: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-1)/var(--pine-line-height-heading) var(--pine-font-family-greet);
   --pine-typography-heading-2: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-2)/var(--pine-line-height-heading) var(--pine-font-family-greet);

--- a/packages/styles/src/tokens/semantic/light.json
+++ b/packages/styles/src/tokens/semantic/light.json
@@ -26,6 +26,21 @@
     }
   },
   "border-radius": {
+    "sm": {
+      "value": "{dimension.050}",
+      "type": "borderRadius",
+      "description": "Small inputs, tight UI elements"
+    },
+    "md": {
+      "value": "{dimension.125}",
+      "type": "borderRadius",
+      "description": "Standard cards, modals"
+    },
+    "lg": {
+      "value": "{dimension.200}",
+      "type": "borderRadius",
+      "description": "Large cards, panels"
+    },
     "full": {
       "value": "9999px",
       "type": "borderRadius",


### PR DESCRIPTION
 **Add semantic border-radius tokens (sm, md, lg)**

  ## Summary

  - Adds `--pine-border-radius-sm` (4px), `--pine-border-radius-md` (10px), and `--pine-border-radius-lg` (16px) semantic tokens, following the same pattern as the existing `--pine-border-radius-full`
  - Values resolve through the core dimension scale (`{dimension.050}`, `{dimension.125}`, `{dimension.200}`) rather than hardcoded px values
  - `--pine-border-radius-full` is unchanged

  ## Context

  These tokens close a semantic gap in the C3 CSS cleanup effort. Previously, border-radius values in the Kajabi admin were being mapped to `--pine-dimension-*` core tokens as an interim — correct values, wrong layer.
   Once the monolith bumps this package, those interim mappings can be updated to use the proper `--pine-border-radius-sm/md/lg` aliases.

  Values are sourced from the Sage radius scale being migrated away from. `10px` (Sage `radius-medium`) and `100px` (Sage `radius-x-large`) were intentionally excluded — `md` and `full` cover their visual intent.