### PR TITLE
fix(alert): add dark mode support for alert component

### DIFF
--- a/packages/styles/_generated/pine/components/pds-alert/pds-alert.tokens.scss
+++ b/packages/styles/_generated/pine/components/pds-alert/pds-alert.tokens.scss
@@ -51,7 +51,7 @@
   --pine-alert-color-dismiss: var(--pine-color-grey-200);
   --pine-alert-color-dismiss-hover: var(--pine-color-grey-700);
   --pine-alert-color-icon: var(--pine-color-grey-300);
-  --pine-alert-color-link: var(--pine-color-grey-200);
+  --pine-alert-color-link: var(--pine-color-grey-300);
   --pine-alert-color-link-hover: var(--pine-color-grey-050);
   --pine-alert-color-text: var(--pine-color-grey-100);
   --pine-alert-color-danger-background: var(--pine-color-red-900);

--- a/packages/styles/_generated/pine/components/pds-alert/pds-alert.tokens.scss
+++ b/packages/styles/_generated/pine/components/pds-alert/pds-alert.tokens.scss
@@ -44,3 +44,46 @@
   --pine-alert-color-warning-link-hover: var(--pine-color-yellow-950);
   --pine-alert-color-warning-text: var(--pine-color-yellow-950);
 }
+
+:host-context([data-theme='dark']) {
+  --pine-alert-color-background: var(--pine-color-grey-800);
+  --pine-alert-color-border: var(--pine-color-grey-600);
+  --pine-alert-color-dismiss: var(--pine-color-grey-200);
+  --pine-alert-color-dismiss-hover: var(--pine-color-grey-700);
+  --pine-alert-color-icon: var(--pine-color-grey-300);
+  --pine-alert-color-link: var(--pine-color-grey-200);
+  --pine-alert-color-link-hover: var(--pine-color-grey-050);
+  --pine-alert-color-text: var(--pine-color-grey-100);
+  --pine-alert-color-danger-background: var(--pine-color-red-900);
+  --pine-alert-color-danger-border: var(--pine-color-red-800);
+  --pine-alert-color-danger-dismiss: var(--pine-color-red-200);
+  --pine-alert-color-danger-dismiss-hover: var(--pine-color-red-800);
+  --pine-alert-color-danger-icon: var(--pine-color-red-400);
+  --pine-alert-color-danger-link: var(--pine-color-red-300);
+  --pine-alert-color-danger-link-hover: var(--pine-color-red-200);
+  --pine-alert-color-danger-text: var(--pine-color-red-100);
+  --pine-alert-color-info-background: var(--pine-color-blue-900);
+  --pine-alert-color-info-border: var(--pine-color-blue-800);
+  --pine-alert-color-info-dismiss: var(--pine-color-blue-200);
+  --pine-alert-color-info-dismiss-hover: var(--pine-color-blue-800);
+  --pine-alert-color-info-icon: var(--pine-color-blue-400);
+  --pine-alert-color-info-link: var(--pine-color-blue-300);
+  --pine-alert-color-info-link-hover: var(--pine-color-blue-200);
+  --pine-alert-color-info-text: var(--pine-color-blue-100);
+  --pine-alert-color-success-background: var(--pine-color-green-900);
+  --pine-alert-color-success-border: var(--pine-color-green-800);
+  --pine-alert-color-success-dismiss: var(--pine-color-green-200);
+  --pine-alert-color-success-dismiss-hover: var(--pine-color-green-800);
+  --pine-alert-color-success-icon: var(--pine-color-green-400);
+  --pine-alert-color-success-link: var(--pine-color-green-300);
+  --pine-alert-color-success-link-hover: var(--pine-color-green-200);
+  --pine-alert-color-success-text: var(--pine-color-green-100);
+  --pine-alert-color-warning-background: var(--pine-color-yellow-900);
+  --pine-alert-color-warning-border: var(--pine-color-yellow-800);
+  --pine-alert-color-warning-dismiss: var(--pine-color-yellow-200);
+  --pine-alert-color-warning-dismiss-hover: var(--pine-color-yellow-800);
+  --pine-alert-color-warning-icon: var(--pine-color-yellow-400);
+  --pine-alert-color-warning-link: var(--pine-color-yellow-300);
+  --pine-alert-color-warning-link-hover: var(--pine-color-yellow-200);
+  --pine-alert-color-warning-text: var(--pine-color-yellow-100);
+}

--- a/packages/styles/src/lib/transform/generators/component.js
+++ b/packages/styles/src/lib/transform/generators/component.js
@@ -11,10 +11,11 @@ const format = "css/variables-host";
 export const generateComponentFiles = () => {
   const filesArr = [];
 
-  // Generates a list of components from the tokens/components folder
-  const components = fs.readdirSync(`${basePath}/components`).map((comp) => comp.replace(/.json$/g, ""));
+  const allFiles = fs.readdirSync(`${basePath}/components`);
+  const lightFiles = allFiles.filter(f => f.endsWith('.json') && !f.includes('-dark'));
 
-  for (const comp of components) {
+  for (const file of lightFiles) {
+    const comp = file.replace('.json', '');
     const componentName = `${componentPrefix}-${comp}`;
 
     // Component-specific tokens at host level (light mode)
@@ -22,7 +23,6 @@ export const generateComponentFiles = () => {
       format,
       filter: (token) => {
         const filePath = token.filePath || '';
-        // Match component files like components/alert.json
         return filePath.includes(`components/${comp}.json`);
       },
       options: {
@@ -31,6 +31,33 @@ export const generateComponentFiles = () => {
         outputReferences: true,
       },
       destination: `pine/components/${componentName}/${componentName}.tokens.scss`,
+    });
+  }
+  return filesArr;
+};
+
+export const generateComponentDarkFiles = () => {
+  const filesArr = [];
+
+  const allFiles = fs.readdirSync(`${basePath}/components`);
+  const darkFiles = allFiles.filter(f => f.includes('-dark.json'));
+
+  for (const darkFile of darkFiles) {
+    const comp = darkFile.replace('-dark.json', '');
+    const componentName = `${componentPrefix}-${comp}`;
+
+    filesArr.push({
+      format,
+      filter: (token) => {
+        const filePath = token.filePath || '';
+        return filePath.includes(`components/${comp}-dark.json`);
+      },
+      options: {
+        selector: ":host-context([data-theme='dark'])",
+        prefix: 'pine',
+        outputReferences: true,
+      },
+      destination: `pine/components/${componentName}/${componentName}.tokens-dark.scss`,
     });
   }
   return filesArr;

--- a/packages/styles/src/lib/transform/generators/index.js
+++ b/packages/styles/src/lib/transform/generators/index.js
@@ -1,3 +1,3 @@
 export { generateCoreFiles } from "./core.js";
-export { generateComponentFiles } from "./component.js";
+export { generateComponentFiles, generateComponentDarkFiles } from "./component.js";
 export { generateSemanticFiles } from "./semantic.js";

--- a/packages/styles/src/lib/transform/index.js
+++ b/packages/styles/src/lib/transform/index.js
@@ -714,7 +714,7 @@ async function run() {
         await fs.writeFile(lightPath, lightContent.trim() + '\n\n' + darkWithoutHeader.trim() + '\n');
         await fs.unlink(darkPath);
       } catch (e) {
-        // No dark file for this component — that's fine
+        if (e.code !== 'ENOENT') throw e;
       }
     }
   }

--- a/packages/styles/src/lib/transform/index.js
+++ b/packages/styles/src/lib/transform/index.js
@@ -1,5 +1,6 @@
 import { register, permutateThemes } from '@tokens-studio/sd-transforms';
-import { generateCoreFiles, generateComponentFiles, generateSemanticFiles } from './generators/index.js';
+import { generateCoreFiles, generateComponentFiles, generateComponentDarkFiles, generateSemanticFiles } from './generators/index.js';
+import { readdirSync } from 'fs';
 import StyleDictionary from 'style-dictionary';
 import { getReferences, usesReferences, outputReferencesTransformed } from "style-dictionary/utils";
 import { promises as fs } from 'fs';
@@ -404,18 +405,20 @@ async function run() {
     },
   };
 
-  // Component-specific configuration
-  // Components have light/dark variants, so we need to handle them per theme
-  // Note: core tokens no longer have dark mode variants
+  // Component-specific configuration — light mode only (dark files excluded to prevent collisions)
+  const lightComponentFiles = readdirSync(`${basePath}/components`)
+    .filter(f => f.endsWith('.json') && !f.includes('-dark'))
+    .map(f => `${basePath}/components/${f}`);
+
   const componentConfig = {
     log: {
       verbosity: 'verbose',
     },
     source: [
-      `${basePath}/brand/core.json`, // Core tokens for reference resolution
+      `${basePath}/brand/core.json`,
       `${basePath}/semantic/light.json`,
       `${basePath}/semantic/dark.json`,
-      `${basePath}/components/**/*.json`
+      ...lightComponentFiles,
     ],
     preprocessors: ['tokens-studio'],
     platforms: {
@@ -428,6 +431,32 @@ async function run() {
       },
     },
   };
+
+  // Dark component configuration — processed separately to prevent token collisions
+  const darkComponentFiles = readdirSync(`${basePath}/components`)
+    .filter(f => f.includes('-dark.json'))
+    .map(f => `${basePath}/components/${f}`);
+
+  const componentDarkConfig = darkComponentFiles.length > 0 ? {
+    log: {
+      verbosity: 'verbose',
+    },
+    source: [
+      `${basePath}/brand/core.json`,
+      `${basePath}/semantic/light.json`,
+      ...darkComponentFiles,
+    ],
+    preprocessors: ['tokens-studio'],
+    platforms: {
+      css: {
+        transformGroup: 'tokens-studio',
+        transforms: ['attribute/themeable', 'name/kebab', 'color/hex', 'ts/resolveMath', 'size/px'],
+        buildPath: buildPath,
+        files: [...generateComponentDarkFiles()],
+        prefix: 'pine'
+      },
+    },
+  } : null;
 
   // Theme-specific configuration
   // Group themes by brand and combine light/dark into single files
@@ -578,12 +607,13 @@ async function run() {
 
   // Build component files
   const componentSd = new StyleDictionary(componentConfig);
+  const componentDarkSd = componentDarkConfig ? new StyleDictionary(componentDarkConfig) : null;
 
   // Build theme files
   const themeSds = themeConfigs.map(config => new StyleDictionary(config));
 
   // Register transform for all configurations
-  const allSds = [coreSdLight, semanticSdLight, semanticSdDark, componentSd, ...themeSds];
+  const allSds = [coreSdLight, semanticSdLight, semanticSdDark, componentSd, ...(componentDarkSd ? [componentDarkSd] : []), ...themeSds];
   for (const sd of allSds) {
     sd.registerTransform({
       name: "attribute/themeable",
@@ -665,6 +695,29 @@ async function run() {
   }
 
   await componentSd.buildAllPlatforms();
+
+  if (componentDarkSd) {
+    await componentDarkSd.buildAllPlatforms();
+
+    // Combine light and dark component files
+    const componentBuildDir = resolve(buildPath, 'pine/components');
+    const componentFolders = await fs.readdir(componentBuildDir);
+    for (const folder of componentFolders) {
+      const lightPath = resolve(componentBuildDir, folder, `${folder}.tokens.scss`);
+      const darkPath = resolve(componentBuildDir, folder, `${folder}.tokens-dark.scss`);
+      try {
+        const [lightContent, darkContent] = await Promise.all([
+          fs.readFile(lightPath, 'utf-8'),
+          fs.readFile(darkPath, 'utf-8'),
+        ]);
+        const darkWithoutHeader = darkContent.replace(/\/\*\*[\s\S]*?\*\/\s*\n\n/, '');
+        await fs.writeFile(lightPath, lightContent.trim() + '\n\n' + darkWithoutHeader.trim() + '\n');
+        await fs.unlink(darkPath);
+      } catch (e) {
+        // No dark file for this component — that's fine
+      }
+    }
+  }
 
   // Build theme files (light and dark separately)
   for (const themeSd of themeSds) {

--- a/packages/styles/src/tokens/components/alert-dark.json
+++ b/packages/styles/src/tokens/components/alert-dark.json
@@ -7,7 +7,7 @@
         "dismiss": { "value": "{color.grey.200}", "type": "color" },
         "dismiss-hover": { "value": "{color.grey.700}", "type": "color" },
         "icon": { "value": "{color.grey.300}", "type": "color" },
-        "link": { "value": "{color.grey.200}", "type": "color" },
+        "link": { "value": "{color.grey.300}", "type": "color" },
         "link-hover": { "value": "{color.grey.050}", "type": "color" },
         "text": { "value": "{color.grey.100}", "type": "color" }
       },

--- a/packages/styles/src/tokens/components/alert-dark.json
+++ b/packages/styles/src/tokens/components/alert-dark.json
@@ -1,0 +1,56 @@
+{
+  "alert": {
+    "color": {
+      "@": {
+        "background": { "value": "{color.grey.800}", "type": "color" },
+        "border": { "value": "{color.grey.600}", "type": "color" },
+        "dismiss": { "value": "{color.grey.200}", "type": "color" },
+        "dismiss-hover": { "value": "{color.grey.700}", "type": "color" },
+        "icon": { "value": "{color.grey.300}", "type": "color" },
+        "link": { "value": "{color.grey.200}", "type": "color" },
+        "link-hover": { "value": "{color.grey.050}", "type": "color" },
+        "text": { "value": "{color.grey.100}", "type": "color" }
+      },
+      "danger": {
+        "background": { "value": "{color.red.900}", "type": "color" },
+        "border": { "value": "{color.red.800}", "type": "color" },
+        "dismiss": { "value": "{color.red.200}", "type": "color" },
+        "dismiss-hover": { "value": "{color.red.800}", "type": "color" },
+        "icon": { "value": "{color.red.400}", "type": "color" },
+        "link": { "value": "{color.red.300}", "type": "color" },
+        "link-hover": { "value": "{color.red.200}", "type": "color" },
+        "text": { "value": "{color.red.100}", "type": "color" }
+      },
+      "info": {
+        "background": { "value": "{color.blue.900}", "type": "color" },
+        "border": { "value": "{color.blue.800}", "type": "color" },
+        "dismiss": { "value": "{color.blue.200}", "type": "color" },
+        "dismiss-hover": { "value": "{color.blue.800}", "type": "color" },
+        "icon": { "value": "{color.blue.400}", "type": "color" },
+        "link": { "value": "{color.blue.300}", "type": "color" },
+        "link-hover": { "value": "{color.blue.200}", "type": "color" },
+        "text": { "value": "{color.blue.100}", "type": "color" }
+      },
+      "success": {
+        "background": { "value": "{color.green.900}", "type": "color" },
+        "border": { "value": "{color.green.800}", "type": "color" },
+        "dismiss": { "value": "{color.green.200}", "type": "color" },
+        "dismiss-hover": { "value": "{color.green.800}", "type": "color" },
+        "icon": { "value": "{color.green.400}", "type": "color" },
+        "link": { "value": "{color.green.300}", "type": "color" },
+        "link-hover": { "value": "{color.green.200}", "type": "color" },
+        "text": { "value": "{color.green.100}", "type": "color" }
+      },
+      "warning": {
+        "background": { "value": "{color.yellow.900}", "type": "color" },
+        "border": { "value": "{color.yellow.800}", "type": "color" },
+        "dismiss": { "value": "{color.yellow.200}", "type": "color" },
+        "dismiss-hover": { "value": "{color.yellow.800}", "type": "color" },
+        "icon": { "value": "{color.yellow.400}", "type": "color" },
+        "link": { "value": "{color.yellow.300}", "type": "color" },
+        "link-hover": { "value": "{color.yellow.200}", "type": "color" },
+        "text": { "value": "{color.yellow.100}", "type": "color" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

  - Adds `alert-dark.json` with dark mode color values for all alert variants (default, danger, info, success, warning), following an inverted color scale: `.900` backgrounds, `.800` borders, `.400` icons, `.100` text
  - Extends the build system to support dark component token files generically — any component with a `*-dark.json` file now automatically gets a `:host([data-theme='dark'])` block in its token output, with no further
   build changes needed
  - Light mode alert tokens are unchanged

  ## How it works

  Previously, component token files only emitted a single `:host { }` block. Dark tokens couldn't simply be added to the same Style Dictionary build as light tokens — same token paths would cause the dark values to
  overwrite light ones, making the light output empty.

  The fix mirrors the existing semantic light/dark pattern: component light and dark tokens are processed in separate Style Dictionary instances, then their outputs are combined into a single file — `:host { }`
  followed by `:host([data-theme='dark']) { }`.

| Light | Dark |
|--------|--------|
|<img width="520" height="342" alt="Screenshot 2026-04-20 at 9 55 04 AM" src="https://github.com/user-attachments/assets/db400997-43f1-47bf-89e5-2d836a6779b3" />|<img width="469" height="344" alt="Screenshot 2026-04-20 at 9 55 19 AM" src="https://github.com/user-attachments/assets/4dfb233d-0a63-436c-a76d-484b29b4ec3e" />|

  ## Dark mode color scale

  | Role | Light | Dark |
  |---|---|---|
  | `background` | `.150` | `.900` |
  | `border` | `.300` | `.800` |
  | `icon` | `.700` | `.400` |
  | `text` | `.950` | `.100` |
  | `link` | `.900` | `.300` |
  | `link-hover` | `.950` | `.200` |
  | `dismiss` | `.900` | `.200` |
  | `dismiss-hover` | `.300` | `.800` |

  ## Files changed

  - `src/tokens/components/alert-dark.json` — new dark token source
  - `src/lib/transform/generators/component.js` — adds `generateComponentDarkFiles()`, filters dark files from light build
  - `src/lib/transform/generators/index.js` — exports new generator
  - `src/lib/transform/index.js` — separate dark component config, combining logic