### PR TITLE
refactor(tokens): remove core Greet font-family tokens (FLEX-2659 + FLEX-2661)

### DIFF
--- a/packages/styles/_generated/base/_core.scss
+++ b/packages/styles/_generated/base/_core.scss
@@ -183,8 +183,6 @@
   --pine-color-teal-900: #134e4a;
   --pine-color-teal-950: #042f2e;
   --pine-color-teal-050: #fbfefe;
-  --pine-font-family-greet: 'Greet Standard', 'Inter', system-ui, 'Segoe UI', 'Roboto', 'Ubuntu', sans-serif;
-  --pine-font-family-greet-condensed: 'Greet Condensed', 'Inter', system-ui, 'Segoe UI', 'Roboto', 'Ubuntu', sans-serif;
   --pine-font-family-inter: 'Inter', system-ui, 'Segoe UI', 'Roboto', 'Ubuntu', sans-serif;
   --pine-font-family-faire-sprig: 'FAIRE Sprig';
   --pine-font-size-100: 14px;

--- a/packages/styles/_generated/base/_semantic.scss
+++ b/packages/styles/_generated/base/_semantic.scss
@@ -179,13 +179,13 @@
   --pine-typography-body-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-monospace);
   --pine-typography-body-semi-bold: var(--pine-font-weight-semi-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-greet);
+  --pine-typography-body-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-faire-sprig);
   --pine-typography-body-sm: var(--pine-font-weight-regular) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-sm-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-sm-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-monospace);
   --pine-typography-body-sm-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-sm-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-greet);
+  --pine-typography-body-sm-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-sm-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-faire-sprig);
   --pine-outline-focus: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
   --pine-outline-focus-danger: var(--pine-border-width-thick) solid var(--pine-color-focus-ring-danger);

--- a/packages/styles/_generated/kajabi_products/kajabi_products.scss
+++ b/packages/styles/_generated/kajabi_products/kajabi_products.scss
@@ -285,8 +285,6 @@
   --pine-color-icon-disabled: var(--pine-color-grey-400);
   --pine-color-icon-inverse: var(--pine-color-white);
   --pine-color-brand: var(--pine-color-grey-950);
-  --pine-font-family-greet: 'Greet Standard', 'Inter', system-ui, 'Segoe UI', 'Roboto', 'Ubuntu', sans-serif;
-  --pine-font-family-greet-condensed: 'Greet Condensed', 'Inter', system-ui, 'Segoe UI', 'Roboto', 'Ubuntu', sans-serif;
   --pine-font-family-inter: 'Inter', system-ui, 'Segoe UI', 'Roboto', 'Ubuntu', sans-serif;
   --pine-font-family-faire-sprig: 'FAIRE Sprig';
   --pine-font-family-heading: var(--pine-font-family-inter);
@@ -440,13 +438,13 @@
   --pine-typography-body-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-monospace);
   --pine-typography-body-semi-bold: var(--pine-font-weight-semi-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-greet);
+  --pine-typography-body-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-faire-sprig);
   --pine-typography-body-sm: var(--pine-font-weight-regular) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-sm-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-sm-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-monospace);
   --pine-typography-body-sm-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-sm-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-greet);
+  --pine-typography-body-sm-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-sm-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-faire-sprig);
   --pine-outline-focus: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
   --pine-outline-focus-danger: var(--pine-border-width-thick) solid var(--pine-color-focus-ring-danger);

--- a/packages/styles/_generated/pine/pine.scss
+++ b/packages/styles/_generated/pine/pine.scss
@@ -285,8 +285,6 @@
   --pine-color-icon-disabled: var(--pine-color-grey-400);
   --pine-color-icon-inverse: var(--pine-color-white);
   --pine-color-brand: var(--pine-color-black);
-  --pine-font-family-greet: 'Greet Standard', 'Inter', system-ui, 'Segoe UI', 'Roboto', 'Ubuntu', sans-serif;
-  --pine-font-family-greet-condensed: 'Greet Condensed', 'Inter', system-ui, 'Segoe UI', 'Roboto', 'Ubuntu', sans-serif;
   --pine-font-family-inter: 'Inter', system-ui, 'Segoe UI', 'Roboto', 'Ubuntu', sans-serif;
   --pine-font-family-faire-sprig: 'FAIRE Sprig';
   --pine-font-family-heading: var(--pine-font-family-inter);
@@ -440,13 +438,13 @@
   --pine-typography-body-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-monospace);
   --pine-typography-body-semi-bold: var(--pine-font-weight-semi-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-greet);
+  --pine-typography-body-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-faire-sprig);
   --pine-typography-body-sm: var(--pine-font-weight-regular) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-sm-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-sm-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-monospace);
   --pine-typography-body-sm-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-sm-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-greet);
+  --pine-typography-body-sm-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-sm-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-faire-sprig);
   --pine-outline-focus: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
   --pine-outline-focus-danger: var(--pine-border-width-thick) solid var(--pine-color-focus-ring-danger);

--- a/packages/styles/src/tokens/brand/core.json
+++ b/packages/styles/src/tokens/brand/core.json
@@ -845,14 +845,6 @@
     }
   },
   "font-family": {
-    "greet": {
-      "value": "Greet Standard, 'Inter', system-ui, Segoe UI, 'Roboto', 'Ubuntu', sans-serif",
-      "type": "fontFamilies"
-    },
-    "greet-condensed": {
-      "value": "Greet Condensed, 'Inter', system-ui, Segoe UI, 'Roboto', 'Ubuntu', sans-serif",
-      "type": "fontFamilies"
-    },
     "inter": {
       "value": "'Inter', system-ui, Segoe UI, 'Roboto', 'Ubuntu', sans-serif",
       "type": "fontFamilies"

--- a/packages/styles/src/tokens/semantic/light.json
+++ b/packages/styles/src/tokens/semantic/light.json
@@ -810,7 +810,7 @@
       },
       "brand-label": {
         "value": {
-          "fontFamily": "{font-family.greet}",
+          "fontFamily": "{font-family.inter}",
           "fontWeight": "{font-weight.medium}",
           "fontSize": "{font-size.body.md}",
           "lineHeight": "{line-height.body} * 100%"
@@ -868,7 +868,7 @@
       },
       "brand-label": {
         "value": {
-          "fontFamily": "{font-family.greet}",
+          "fontFamily": "{font-family.inter}",
           "fontWeight": "{font-weight.medium}",
           "fontSize": "{font-size.body.sm}",
           "lineHeight": "{line-height.body} * 100%"


### PR DESCRIPTION
## Summary

- Completes **FLEX-2659**: updates `typography.body.brand-label` and `typography.body-sm.brand-label` in `semantic/light.json` to reference `{font-family.inter}` instead of `{font-family.greet}` (heading tokens were already updated in #30)
- Closes **FLEX-2661**: removes the `font-family.greet` and `font-family.greet-condensed` core token definitions from `brand/core.json`

After this PR, `--pine-font-family-greet` and `--pine-font-family-greet-condensed` no longer exist as compiled CSS custom properties.

## Verification

- Build passes ✅
- `grep -i greet pine.css kajabi_products.css` returns nothing ✅
- KP already removed all usages of `var(--pine-font-family-greet*)` in KP PR #51619 (FLEX-2670, merged)

## Test plan

- [ ] Confirm `dist/pine/pine.css` contains no `greet` references after build
- [ ] Confirm `dist/kajabi_products/kajabi_products.css` contains no `greet` references after build
- [ ] Confirm `--pine-font-family-heading` and all heading typography tokens resolve to Inter in browser DevTools after dep update in KP