### PR TITLE
fix(tokens): update brand dark mode token to grey-050

### DIFF
--- a/packages/styles/_generated/base/_semantic.scss
+++ b/packages/styles/_generated/base/_semantic.scss
@@ -291,7 +291,7 @@
   --pine-color-icon-subtle: var(--pine-color-grey-400);
   --pine-color-icon-disabled: var(--pine-color-grey-500);
   --pine-color-icon-inverse: var(--pine-color-grey-900);
-  --pine-color-brand: var(--pine-color-black);
+  --pine-color-brand: var(--pine-color-grey-050);
   --pine-border: var(--pine-border-width-thin) solid var(--pine-color-grey-600);
   --pine-border-hover: var(--pine-border-width-thin) solid var(--pine-color-grey-400);
   --pine-border-none: var(--pine-border-width-none) solid var(--pine-color-grey-600);

--- a/packages/styles/_generated/pine/pine.scss
+++ b/packages/styles/_generated/pine/pine.scss
@@ -552,7 +552,7 @@
   --pine-color-icon-subtle: var(--pine-color-grey-400);
   --pine-color-icon-disabled: var(--pine-color-grey-500);
   --pine-color-icon-inverse: var(--pine-color-grey-900);
-  --pine-color-brand: var(--pine-color-black);
+  --pine-color-brand: var(--pine-color-grey-050);
   --pine-border: var(--pine-border-width-thin) solid var(--pine-color-grey-600);
   --pine-border-hover: var(--pine-border-width-thin) solid var(--pine-color-grey-400);
   --pine-border-none: var(--pine-border-width-none) solid var(--pine-color-grey-600);

--- a/packages/styles/src/tokens/semantic/dark.json
+++ b/packages/styles/src/tokens/semantic/dark.json
@@ -492,7 +492,7 @@
     },
     "brand": {
       "@": {
-        "value": "{color.black}",
+        "value": "{color.grey.050}",
         "type": "color"
       }
     }


### PR DESCRIPTION
## Summary

- Fixes `--pine-color-brand` resolving to `#000000` in dark mode (FLEX-2853)
- Updates `semantic/dark.json`: `color.brand` from `{color.black}` to `{color.grey.050}` (`#fcfcfc`)
- The base Pine theme now has a proper light/dark inversion for `--pine-color-brand` (black in light, off-white in dark)

## Context

`pine-core.css` is built from `@kajabi-ui/styles/dist/pine/pine.css`. Before this fix, both `:root` and `[data-theme=dark]` set `--pine-color-brand` to `var(--pine-color-black)` — making the brand color invisible on dark backgrounds.

The `kajabi_products` theme already had the correct dark-mode flip (`grey.950` / `grey.100`), but that's a per-consumer override. This fix corrects the semantic baseline so the `pine` theme itself is sensible.

## Token diff

| File | Mode | Before | After |
|---|---|---|---|
| `semantic/dark.json` | dark | `{color.black}` → `#000000` | `{color.grey.050}` → `#fcfcfc` |
| `semantic/light.json` | light | `{color.black}` → `#000000` | unchanged |

## Test plan

- [ ] Build passes (`npm run build` in `packages/styles`)
- [ ] `dist/pine/pine.css` dark mode: `--pine-color-brand: var(--pine-color-grey-050)`
- [ ] `dist/kajabi_products/kajabi_products.css` unchanged (KP theme overrides are unaffected)
- [ ] After a Pine rebuild picking up this version, `pine-core.css` dark mode brand resolves to `#fcfcfc`