### PR TITLE
fix(release): use kajabi-github-actions PAT to bypass branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ on:
     secrets:
       NPM_TOKEN:
         required: true
-      GH_WRITE_TOKEN:
+      KAJABI_CI_GH_TOKEN:
         required: true
 
   workflow_dispatch:
@@ -80,7 +80,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_WRITE_TOKEN }}
+          token: ${{ secrets.KAJABI_CI_GH_TOKEN }}
 
       - name: Setup
         uses: ./.github/workflows/actions/setup
@@ -103,7 +103,7 @@ jobs:
         if: ${{ inputs.version == '' }}
         run: npx nx release --yes
         env:
-          GH_TOKEN: ${{ secrets.GH_WRITE_TOKEN }}
+          GH_TOKEN: ${{ secrets.KAJABI_CI_GH_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
         ### Steps below are used for releasing a specified version type (major, minor, patch, etc.)
@@ -111,7 +111,7 @@ jobs:
         if: ${{ inputs.version != '' }}
         run: npx nx release ${{ github.event.inputs.version }} --preid ${{ inputs.preid }} --yes
         env:
-          GH_TOKEN: ${{ secrets.GH_WRITE_TOKEN }}
+          GH_TOKEN: ${{ secrets.KAJABI_CI_GH_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ on:
     secrets:
       NPM_TOKEN:
         required: true
+      GH_WRITE_TOKEN:
+        required: true
 
   workflow_dispatch:
     inputs:
@@ -78,6 +80,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_WRITE_TOKEN }}
 
       - name: Setup
         uses: ./.github/workflows/actions/setup
@@ -100,7 +103,7 @@ jobs:
         if: ${{ inputs.version == '' }}
         run: npx nx release --yes
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_WRITE_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
         ### Steps below are used for releasing a specified version type (major, minor, patch, etc.)
@@ -108,7 +111,7 @@ jobs:
         if: ${{ inputs.version != '' }}
         run: npx nx release ${{ github.event.inputs.version }} --preid ${{ inputs.preid }} --yes
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_WRITE_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 


### PR DESCRIPTION
## Summary
- Replaces \`GITHUB_TOKEN\` (ephemeral \`github-actions[bot]\`, can't be bypass-listed) with \`KAJABI_CI_GH_TOKEN\` (kajabi-ci service account PAT, already on the branch protection bypass list)
- Adds \`token: \${{ secrets.KAJABI_CI_GH_TOKEN }}\` to the checkout step so release commits/tags are authored by the service account
- Updates both \`GH_TOKEN\` env vars in the Release and Release with Input Version steps
- Adds \`KAJABI_CI_GH_TOKEN\` to the \`workflow_call\` secrets declaration for reusable workflow callers

Follows the same pattern used in [datadog_dashboards #14](https://github.com/Kajabi/datadog_dashboards/pull/14).

## Pre-req
✅ \`KAJABI_CI_GH_TOKEN\` secret has been added to the ds-tokens repo by Paul.

## Test plan
- [ ] Trigger workflow manually via \`workflow_dispatch\` with \`version=prerelease\`, \`preid=dev\`, \`tag=dev\` to verify the push succeeds past branch protection