### PR TITLE
fix: override GITHUB_TOKEN in release steps to force PAT auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,7 @@ jobs:
         run: npx nx release --yes
         env:
           GH_TOKEN: ${{ secrets.KAJABI_CI_GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.KAJABI_CI_GH_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
         ### Steps below are used for releasing a specified version type (major, minor, patch, etc.)
@@ -112,6 +113,7 @@ jobs:
         run: npx nx release ${{ github.event.inputs.version }} --preid ${{ inputs.preid }} --yes
         env:
           GH_TOKEN: ${{ secrets.KAJABI_CI_GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.KAJABI_CI_GH_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 


### PR DESCRIPTION
## Summary
- nx release's `git push` picks up the auto-injected `GITHUB_TOKEN` (`github-actions[bot]`) even when `actions/checkout` is configured with a PAT — confirmed via the branch protection violation log
- Explicitly setting `GITHUB_TOKEN: ${{ secrets.KAJABI_CI_GH_TOKEN }}` in the release step env overrides the injected token and forces git operations to authenticate as kajabi-ci

## Test plan
- [ ] Trigger workflow via `workflow_dispatch` with `version=prerelease`, `preid=dev`, `tag=dev` and confirm the push succeeds past branch protection

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that alters which GitHub credentials `nx release` uses for pushes/tags; main risk is unintended permission differences if the PAT is mis-scoped.
> 
> **Overview**
> For the release workflow, explicitly sets `GITHUB_TOKEN` to the `KAJABI_CI_GH_TOKEN` PAT in both `nx release` steps so git operations authenticate as the PAT user rather than the default `github-actions[bot]` token (helping satisfy branch protection rules).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 548b0cb7d131b8f5e0d6732de8cea977687b6019. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->