### PR TITLE
fix(release): pin origin remote to PAT to bypass branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,11 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.KAJABI_CI_GH_TOKEN }}
 
+      - name: Pin origin remote to PAT identity
+        run: git remote set-url origin "https://x-access-token:${KAJABI_CI_GH_TOKEN}@github.com/${{ github.repository }}.git"
+        env:
+          KAJABI_CI_GH_TOKEN: ${{ secrets.KAJABI_CI_GH_TOKEN }}
+
       - name: Setup
         uses: ./.github/workflows/actions/setup
         with:


### PR DESCRIPTION
## Summary
- Force the `origin` remote to use the `KAJABI_CI_GH_TOKEN` PAT directly in the URL after checkout, so `nx release`'s `git push` authenticates as the bots-team PAT identity instead of `github-actions[bot]`.

## Background
The previous release run (https://github.com/Kajabi/ds-tokens/actions/runs/25459124479) failed at the push step with:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
- Changes must be made through a pull request.
```

The org-level "Protect default branch" ruleset requires PRs and lists the `bots` team (which includes `kajabi-ci`) as a bypass actor. The PAT is correctly wired into `actions/checkout` and `GH_TOKEN`, but `actions/checkout@v6` changed credential persistence to a helper file under `$RUNNER_TEMP` rather than an inline `extraheader` in `.git/config`. `nx release`'s subsequent `git push` was falling back to the workflow `github-actions[bot]` token, which is not a bypass actor — hence the rejection.

Rewriting `origin` to embed the PAT in the URL guarantees every git operation in the job authenticates as the PAT owner, restoring the bypass.

## Test plan
- [ ] Re-run the `DS Tokens Release` workflow via `workflow_dispatch` and confirm the version-bump commit and tag push to `main` succeed.
- [ ] Verify the resulting commit is authored/pushed by the PAT account, not `github-actions[bot]`.