### PR TITLE
fix(release): drop redundant checkout that wiped PAT auth

### DIFF
--- a/.github/workflows/actions/setup/action.yml
+++ b/.github/workflows/actions/setup/action.yml
@@ -4,15 +4,6 @@ description: 'Runs the prerequisites for the Jobs'
 runs:
   using: 'composite'
   steps:
-    - name: Checkout
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-
-    - name: Get Latest
-      run: git pull
-      shell: bash
-
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,11 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.KAJABI_CI_GH_TOKEN }}
 
+      - name: Pin origin remote to PAT identity
+        run: git remote set-url origin "https://x-access-token:${KAJABI_CI_GH_TOKEN}@github.com/${{ github.repository }}.git"
+        env:
+          KAJABI_CI_GH_TOKEN: ${{ secrets.KAJABI_CI_GH_TOKEN }}
+
       - name: Setup
         uses: ./.github/workflows/actions/setup
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,11 +82,6 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.KAJABI_CI_GH_TOKEN }}
 
-      - name: Pin origin remote to PAT identity
-        run: git remote set-url origin "https://x-access-token:${KAJABI_CI_GH_TOKEN}@github.com/${{ github.repository }}.git"
-        env:
-          KAJABI_CI_GH_TOKEN: ${{ secrets.KAJABI_CI_GH_TOKEN }}
-
       - name: Setup
         uses: ./.github/workflows/actions/setup
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 1.1.2 (2026-05-06)
+
+### Bug Fixes 🐛
+
+- use KAJABI_CI_GH_TOKEN to match org bot convention ([5260f6b](https://github.com/Kajabi/ds-tokens/commit/5260f6b))
+- **FLEX-3032:** make kajabi_products.css fully self-contained; drop pine-core.css dependency ([1e63667](https://github.com/Kajabi/ds-tokens/commit/1e63667))
+- **release:** use kajabi-github-actions PAT to bypass branch protection ([40eacf2](https://github.com/Kajabi/ds-tokens/commit/40eacf2))
+- **release:** pin origin remote to PAT to bypass branch protection ([06f815a](https://github.com/Kajabi/ds-tokens/commit/06f815a))
+- **release:** drop redundant checkout in setup that wiped PAT auth ([d77c603](https://github.com/Kajabi/ds-tokens/commit/d77c603))
+- **styles:** strip duplicate Pine tokens from kajabi_products.css (FLEX-3032) ([3e9f211](https://github.com/Kajabi/ds-tokens/commit/3e9f211))
+- **transform:** keep auto-generated banner at line 1 in kajabi_products.css ([12304a0](https://github.com/Kajabi/ds-tokens/commit/12304a0))
+
+### ❤️ Thank You
+
+- Paul Simpson
+- Quinton Jason
+
 ## 1.1.1 (2026-04-29)
 
 ### Bug Fixes 🐛

--- a/package-lock.json
+++ b/package-lock.json
@@ -11500,7 +11500,7 @@
     },
     "packages/styles": {
       "name": "@kajabi-ui/styles",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "devDependencies": {
         "@tokens-studio/sd-transforms": "^1.3.0",
         "fs-extra": "^11.3.0",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -2,7 +2,7 @@
   "name": "@kajabi-ui/styles",
   "author": "Kajabi Design System Services",
   "description": "A collection of styles and tokens used within Kajabi",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "type": "module",
   "exports": {
     "./package.json": "./package.json",


### PR DESCRIPTION
## Summary
- Remove the redundant `actions/checkout@v6` (and its `git pull`) from `.github/workflows/actions/setup/action.yml`. Those steps overwrote the PAT credentials configured by the release job's prior checkout, causing `nx release`'s `git push` to authenticate as `github-actions[bot]` instead of the bots-team PAT.
- Drop the remote-pin step added in #38 — it ran before Setup, so Setup's re-checkout wiped that too. With Setup no longer re-checking out, the parent workflow's PAT auth holds through to the push.

## Background
The most recent release run (https://github.com/Kajabi/ds-tokens/actions/runs/25460643803) still failed with:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
- Changes must be made through a pull request.
```

The Setup composite action did its own checkout with no token, which:

1. Reset `origin` URL to plain `https://github.com/Kajabi/ds-tokens` (undoing the pin).
2. Rewrote `http.https://github.com/.extraheader` to use the default `GITHUB_TOKEN`.

`nx release`'s subsequent `git push` then authenticated as `github-actions[bot]`, which is not in the "Protect default branch" org ruleset's bypass actors (the `bots` team is, but the workflow bot is not), so the push was rejected.

The Setup checkout was redundant — `release.yml` (and `build.yml`) already check out the repo before invoking it. Build's own composite actions (`build-styles`, `test-lint`) don't use Setup, so removing the checkout from Setup affects only the release flow.

## Test plan
- [ ] Re-dispatch the `DS Tokens Release` workflow and confirm the version-bump commit and tag push to `main` succeed.
- [ ] Verify the resulting commit on `main` is pushed by the PAT identity, not `github-actions[bot]`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the composite `Setup` action used by `release.yml`, which can impact CI/release behavior and git authentication during automated version bumps and pushes.
> 
> **Overview**
> Prevents the release workflow from losing its PAT-based git credentials by **removing the redundant `actions/checkout` + `git pull`** from the `Setup` composite action.
> 
> Bumps `@kajabi-ui/styles` to `1.1.2` (lockfile + package.json) and updates `CHANGELOG.md` with the `1.1.2` release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5ec472108f9bd55e9f312fff1cc0f11513975eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->