### PR TITLE
feat(chip): add dark-mode tokens

### DIFF
--- a/packages/styles/_generated/pine/components/pds-chip/pds-chip.tokens.scss
+++ b/packages/styles/_generated/pine/components/pds-chip/pds-chip.tokens.scss
@@ -6,19 +6,52 @@
   --pine-chip-color-accent: var(--pine-color-purple-100);
   --pine-chip-color-accent-hover: var(--pine-color-purple-300);
   --pine-chip-color-accent-dot: var(--pine-color-purple-600);
+  --pine-chip-color-accent-text: var(--pine-color-purple-950);
   --pine-chip-color-danger: var(--pine-color-red-100);
   --pine-chip-color-danger-hover: var(--pine-color-red-300);
   --pine-chip-color-danger-dot: var(--pine-color-red-600);
+  --pine-chip-color-danger-text: var(--pine-color-red-950);
   --pine-chip-color-info: var(--pine-color-blue-100);
   --pine-chip-color-info-hover: var(--pine-color-blue-300);
   --pine-chip-color-info-dot: var(--pine-color-blue-600);
+  --pine-chip-color-info-text: var(--pine-color-blue-950);
   --pine-chip-color-neutral: var(--pine-color-grey-100);
   --pine-chip-color-neutral-hover: var(--pine-color-grey-300);
   --pine-chip-color-neutral-dot: var(--pine-color-grey-600);
+  --pine-chip-color-neutral-text: var(--pine-color-grey-950);
   --pine-chip-color-success: var(--pine-color-green-100);
   --pine-chip-color-success-hover: var(--pine-color-green-300);
   --pine-chip-color-success-dot: var(--pine-color-green-600);
+  --pine-chip-color-success-text: var(--pine-color-green-950);
   --pine-chip-color-warning: var(--pine-color-yellow-100);
   --pine-chip-color-warning-hover: var(--pine-color-yellow-300);
   --pine-chip-color-warning-dot: var(--pine-color-yellow-600);
+  --pine-chip-color-warning-text: var(--pine-color-yellow-950);
+}
+
+:host-context([data-theme='dark']) {
+  --pine-chip-color-accent: var(--pine-color-purple-900);
+  --pine-chip-color-accent-hover: var(--pine-color-purple-800);
+  --pine-chip-color-accent-dot: var(--pine-color-purple-400);
+  --pine-chip-color-accent-text: var(--pine-color-purple-100);
+  --pine-chip-color-danger: var(--pine-color-red-900);
+  --pine-chip-color-danger-hover: var(--pine-color-red-800);
+  --pine-chip-color-danger-dot: var(--pine-color-red-400);
+  --pine-chip-color-danger-text: var(--pine-color-red-100);
+  --pine-chip-color-info: var(--pine-color-blue-900);
+  --pine-chip-color-info-hover: var(--pine-color-blue-800);
+  --pine-chip-color-info-dot: var(--pine-color-blue-400);
+  --pine-chip-color-info-text: var(--pine-color-blue-100);
+  --pine-chip-color-neutral: var(--pine-color-grey-800);
+  --pine-chip-color-neutral-hover: var(--pine-color-grey-600);
+  --pine-chip-color-neutral-dot: var(--pine-color-grey-300);
+  --pine-chip-color-neutral-text: var(--pine-color-grey-100);
+  --pine-chip-color-success: var(--pine-color-green-900);
+  --pine-chip-color-success-hover: var(--pine-color-green-800);
+  --pine-chip-color-success-dot: var(--pine-color-green-400);
+  --pine-chip-color-success-text: var(--pine-color-green-100);
+  --pine-chip-color-warning: var(--pine-color-yellow-900);
+  --pine-chip-color-warning-hover: var(--pine-color-yellow-800);
+  --pine-chip-color-warning-dot: var(--pine-color-yellow-400);
+  --pine-chip-color-warning-text: var(--pine-color-yellow-100);
 }

--- a/packages/styles/src/tokens/components/chip-dark.json
+++ b/packages/styles/src/tokens/components/chip-dark.json
@@ -3,109 +3,109 @@
     "color": {
       "accent": {
         "@": {
-          "value": "{color.purple.100}",
+          "value": "{color.purple.900}",
           "type": "color"
         },
         "hover": {
-          "value": "{color.purple.300}",
+          "value": "{color.purple.800}",
           "type": "color"
         },
         "dot": {
-          "value": "{color.purple.600}",
+          "value": "{color.purple.400}",
           "type": "color"
         },
         "text": {
-          "value": "{color.purple.950}",
+          "value": "{color.purple.100}",
           "type": "color"
         }
       },
       "danger": {
         "@": {
-          "value": "{color.red.100}",
+          "value": "{color.red.900}",
           "type": "color"
         },
         "hover": {
-          "value": "{color.red.300}",
+          "value": "{color.red.800}",
           "type": "color"
         },
         "dot": {
-          "value": "{color.red.600}",
+          "value": "{color.red.400}",
           "type": "color"
         },
         "text": {
-          "value": "{color.red.950}",
+          "value": "{color.red.100}",
           "type": "color"
         }
       },
       "info": {
         "@": {
-          "value": "{color.blue.100}",
+          "value": "{color.blue.900}",
           "type": "color"
         },
         "hover": {
-          "value": "{color.blue.300}",
+          "value": "{color.blue.800}",
           "type": "color"
         },
         "dot": {
-          "value": "{color.blue.600}",
+          "value": "{color.blue.400}",
           "type": "color"
         },
         "text": {
-          "value": "{color.blue.950}",
+          "value": "{color.blue.100}",
           "type": "color"
         }
       },
       "neutral": {
         "@": {
-          "value": "{color.grey.100}",
+          "value": "{color.grey.800}",
           "type": "color"
         },
         "hover": {
-          "value": "{color.grey.300}",
-          "type": "color"
-        },
-        "dot": {
           "value": "{color.grey.600}",
           "type": "color"
         },
+        "dot": {
+          "value": "{color.grey.300}",
+          "type": "color"
+        },
         "text": {
-          "value": "{color.grey.950}",
+          "value": "{color.grey.100}",
           "type": "color"
         }
       },
       "success": {
         "@": {
-          "value": "{color.green.100}",
+          "value": "{color.green.900}",
           "type": "color"
         },
         "hover": {
-          "value": "{color.green.300}",
+          "value": "{color.green.800}",
           "type": "color"
         },
         "dot": {
-          "value": "{color.green.600}",
+          "value": "{color.green.400}",
           "type": "color"
         },
         "text": {
-          "value": "{color.green.950}",
+          "value": "{color.green.100}",
           "type": "color"
         }
       },
       "warning": {
         "@": {
-          "value": "{color.yellow.100}",
+          "value": "{color.yellow.900}",
           "type": "color"
         },
         "hover": {
-          "value": "{color.yellow.300}",
+          "value": "{color.yellow.800}",
           "type": "color"
         },
         "dot": {
-          "value": "{color.yellow.600}",
+          "value": "{color.yellow.400}",
           "type": "color"
         },
         "text": {
-          "value": "{color.yellow.950}",
+          "value": "{color.yellow.100}",
           "type": "color"
         }
       }


### PR DESCRIPTION
## Summary
- Adds `chip-dark.json` so `pds-chip` backgrounds, hover, dots, and text flip under `[data-theme='dark']`. Mirrors the existing `alert.json` / `alert-dark.json` pair and the established light→dark scale mapping (`bg *.150→*.900`, `hover *.300→*.800`, `dot *.700→*.400`, `text *.950→*.100`).
- Adds a new `text` key to each sentiment in `chip.json` so the dark scope has a counterpart to flip — closes a gap where `pds-chip` had no chip-namespaced text token at all.
- Regenerates `_generated/pine/components/pds-chip/pds-chip.tokens.scss` with the appended `:host-context([data-theme='dark'])` block.

## Why
Reported on the Automations admin view: sentiment chips render with light-mode purple/blue/green/etc. backgrounds even when the admin is in dark mode. Root cause was that every `--pine-chip-color-*` semantic in `chip.json` resolved to a single light-only primitive (`*.100`) with no dark counterpart and no `text` token. The repo's generator already supports `components/*-dark.json` by filename convention (same path `alert-dark.json` follows) — this PR activates that path for chip.

## Build pipeline
No changes to `$metadata.json` / `$themes.json`. `src/lib/transform/generators/component.js` auto-discovers `components/*-dark.json` and emits a `:host-context([data-theme='dark'])` block that gets appended to the light tokens file.

## Follow-ups (not in this PR)
1. **Pine SCSS adoption.** `pds-chip.scss` currently uses `--pine-color-text-{sentiment}` for label colors and `--pine-color-grey-900` (raw primitive, stylelint-disable in source) for neutral. Until a Pine PR swaps to the new `--pine-chip-color-{sentiment}-text` tokens, only chip **backgrounds/hover/dots** flip in dark mode — text won't, and neutral text on a dark chip will be unreadable. The Pine SCSS PR is the second half of this feature.
2. **`alert-dark.json` is in the same state** — present in source, generator emits the SCSS, but `pds-alert.scss` doesn't consume the dark scope yet. Parallel ticket worth filing.

## Test plan
- [ ] Run `npm run generate` in `packages/styles` — confirm `_generated/pine/components/pds-chip/pds-chip.tokens.scss` contains both `:host` and `:host-context([data-theme='dark'])` blocks with all 6 sentiments × {bg, hover, dot, text}
- [ ] Verify generated CSS variable names match what `pds-chip.scss` consumes (`--pine-chip-color-{sentiment}`, `-hover`, `-dot`)
- [ ] Cut a pre-release / link a Pine PR that consumes the dark-mode tokens end-to-end before this gets adopted by `kajabi-products`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk design-token changes that only affect `pds-chip` styling via generated CSS variables. Main risk is visual regressions/contrast issues in dark theme if consuming SCSS expects different token names or values.
> 
> **Overview**
> Adds chip-specific `text` color tokens for each sentiment and introduces `chip-dark.json` to define dark-theme equivalents.
> 
> Regenerates `pds-chip.tokens.scss` to include the new `--pine-chip-color-*-text` variables and a `:host-context([data-theme='dark'])` block that overrides chip background/hover/dot/text colors in dark mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da19bf7a9f72e12c2f577da74d2e58cb2d2154d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->