### PR TITLE
feat: publish motion duration and easing tokens

### DIFF
--- a/packages/styles/_generated/base/_core.scss
+++ b/packages/styles/_generated/base/_core.scss
@@ -270,6 +270,8 @@
   --pine-z-index-9: 9000;
   --pine-z-index-n1: -1;
 }
+
+
 @media (prefers-reduced-motion: reduce) {
   :root {
     --pine-motion-duration-fast: 0ms;

--- a/packages/styles/_generated/base/_core.scss
+++ b/packages/styles/_generated/base/_core.scss
@@ -252,6 +252,13 @@
   --pine-letter-spacing-185: 0.26px;
   --pine-letter-spacing-078: 0.11px;
   --pine-letter-spacing-085: 0.12px;
+  --pine-motion-duration-none: 0ms;
+  --pine-motion-duration-fast: 120ms;
+  --pine-motion-duration-base: 200ms;
+  --pine-motion-duration-slow: 300ms;
+  --pine-motion-easing-out: cubic-bezier(0, 0, 0.2, 1);
+  --pine-motion-easing-in: cubic-bezier(0.4, 0, 1, 1);
+  --pine-motion-easing-in-out: cubic-bezier(0.4, 0, 0.2, 1);
   --pine-z-index-0: 0;
   --pine-z-index-1: 1000;
   --pine-z-index-2: 2000;
@@ -263,4 +270,10 @@
   --pine-z-index-9: 9000;
   --pine-z-index-n1: -1;
 }
-
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --pine-motion-duration-fast: 0ms;
+    --pine-motion-duration-base: 0ms;
+    --pine-motion-duration-slow: 0ms;
+  }
+}

--- a/packages/styles/_generated/kajabi_products/kajabi_products.scss
+++ b/packages/styles/_generated/kajabi_products/kajabi_products.scss
@@ -491,6 +491,15 @@
   --pine-outline-focus-danger: var(--pine-border-width-thick) solid var(--pine-color-focus-ring-danger);
 }
 
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --pine-motion-duration-fast: 0ms;
+    --pine-motion-duration-base: 0ms;
+    --pine-motion-duration-slow: 0ms;
+  }
+}
+
 [data-theme="dark"] {
   --pine-color-accent: var(--pine-color-purple-500);
   --pine-color-accent-disabled: var(--pine-color-purple-100);
@@ -606,11 +615,4 @@
   --pine-color-accent-disabled: var(--kj-brand-primary, var(--pine-color-purple-100));
   --pine-color-accent-hover:   var(--kj-brand-primary, var(--pine-color-purple-600));
   --pine-color-focus-ring:     var(--kj-brand-primary, var(--pine-color-purple-300));
-}
-@media (prefers-reduced-motion: reduce) {
-  :root {
-    --pine-motion-duration-fast: 0ms;
-    --pine-motion-duration-base: 0ms;
-    --pine-motion-duration-slow: 0ms;
-  }
 }

--- a/packages/styles/_generated/kajabi_products/kajabi_products.scss
+++ b/packages/styles/_generated/kajabi_products/kajabi_products.scss
@@ -433,6 +433,13 @@
   --pine-letter-spacing-heading-4: var(--pine-letter-spacing-142);
   --pine-letter-spacing-heading-5: var(--pine-letter-spacing-128);
   --pine-letter-spacing-heading-6: var(--pine-letter-spacing-114);
+  --pine-motion-duration-none: 0ms;
+  --pine-motion-duration-fast: 120ms;
+  --pine-motion-duration-base: 200ms;
+  --pine-motion-duration-slow: 300ms;
+  --pine-motion-easing-out: cubic-bezier(0, 0, 0.2, 1);
+  --pine-motion-easing-in: cubic-bezier(0.4, 0, 1, 1);
+  --pine-motion-easing-in-out: cubic-bezier(0.4, 0, 0.2, 1);
   --pine-z-index-0: 0;
   --pine-z-index-1: 1000;
   --pine-z-index-2: 2000;
@@ -599,4 +606,11 @@
   --pine-color-accent-disabled: var(--kj-brand-primary, var(--pine-color-purple-100));
   --pine-color-accent-hover:   var(--kj-brand-primary, var(--pine-color-purple-600));
   --pine-color-focus-ring:     var(--kj-brand-primary, var(--pine-color-purple-300));
+}
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --pine-motion-duration-fast: 0ms;
+    --pine-motion-duration-base: 0ms;
+    --pine-motion-duration-slow: 0ms;
+  }
 }

--- a/packages/styles/_generated/pine/pine.scss
+++ b/packages/styles/_generated/pine/pine.scss
@@ -399,6 +399,13 @@
   --pine-letter-spacing-heading-4: var(--pine-letter-spacing-142);
   --pine-letter-spacing-heading-5: var(--pine-letter-spacing-128);
   --pine-letter-spacing-heading-6: var(--pine-letter-spacing-114);
+  --pine-motion-duration-none: 0ms;
+  --pine-motion-duration-fast: 120ms;
+  --pine-motion-duration-base: 200ms;
+  --pine-motion-duration-slow: 300ms;
+  --pine-motion-easing-out: cubic-bezier(0, 0, 0.2, 1);
+  --pine-motion-easing-in: cubic-bezier(0.4, 0, 1, 1);
+  --pine-motion-easing-in-out: cubic-bezier(0.4, 0, 0.2, 1);
   --pine-z-index-0: 0;
   --pine-z-index-1: 1000;
   --pine-z-index-2: 2000;
@@ -554,4 +561,11 @@
   --pine-border: var(--pine-border-width-thin) solid var(--pine-color-grey-600);
   --pine-border-hover: var(--pine-border-width-thin) solid var(--pine-color-grey-400);
   --pine-border-none: var(--pine-border-width-none) solid var(--pine-color-grey-600);
+}
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --pine-motion-duration-fast: 0ms;
+    --pine-motion-duration-base: 0ms;
+    --pine-motion-duration-slow: 0ms;
+  }
 }

--- a/packages/styles/_generated/pine/pine.scss
+++ b/packages/styles/_generated/pine/pine.scss
@@ -457,6 +457,15 @@
   --pine-outline-focus-danger: var(--pine-border-width-thick) solid var(--pine-color-focus-ring-danger);
 }
 
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --pine-motion-duration-fast: 0ms;
+    --pine-motion-duration-base: 0ms;
+    --pine-motion-duration-slow: 0ms;
+  }
+}
+
 [data-theme="dark"] {
   --pine-color-accent: var(--pine-color-purple-500);
   --pine-color-accent-disabled: var(--pine-color-purple-100);
@@ -561,11 +570,4 @@
   --pine-border: var(--pine-border-width-thin) solid var(--pine-color-grey-600);
   --pine-border-hover: var(--pine-border-width-thin) solid var(--pine-color-grey-400);
   --pine-border-none: var(--pine-border-width-none) solid var(--pine-color-grey-600);
-}
-@media (prefers-reduced-motion: reduce) {
-  :root {
-    --pine-motion-duration-fast: 0ms;
-    --pine-motion-duration-base: 0ms;
-    --pine-motion-duration-slow: 0ms;
-  }
 }

--- a/packages/styles/src/lib/transform/index.js
+++ b/packages/styles/src/lib/transform/index.js
@@ -13,6 +13,24 @@ register(StyleDictionary, {
 
 const buildPath = `_generated/`;
 
+// Duration tokens collapse to 0ms under prefers-reduced-motion so components
+// referencing var(--pine-motion-duration-*) inherit the override automatically.
+const motionReducedBlock = `
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --pine-motion-duration-fast: 0ms;
+    --pine-motion-duration-base: 0ms;
+    --pine-motion-duration-slow: 0ms;
+  }
+}`;
+
+async function appendMotionReducedBlock(filePath) {
+  const content = await fs.readFile(filePath, 'utf-8');
+  if (content.includes('--pine-motion-duration-fast') && !content.includes('prefers-reduced-motion')) {
+    await fs.writeFile(filePath, content.trimEnd() + motionReducedBlock + '\n');
+  }
+}
+
 // Custom format for component CSS variables with :host selector
 StyleDictionary.registerFormat({
   name: 'css/variables-host',
@@ -646,6 +664,7 @@ async function run() {
   // Build all platforms in order
   // Build light first to temp files, then dark to temp files, then combine
   await coreSdLight.buildAllPlatforms();
+  await appendMotionReducedBlock(resolve(buildPath, 'base/_core.scss'));
   await semanticSdLight.buildAllPlatforms();
   await semanticSdDark.buildAllPlatforms();
 
@@ -775,6 +794,7 @@ async function run() {
         ? header + fontFaceBlock + body + siteBrandOverride + '\n'
         : combined;
       await fs.writeFile(finalPath, finalContent);
+      await appendMotionReducedBlock(finalPath);
       await fs.unlink(darkPath);
     } catch (e) {
       console.warn(`Could not combine ${brandName} files:`, e.message);

--- a/packages/styles/src/lib/transform/index.js
+++ b/packages/styles/src/lib/transform/index.js
@@ -24,13 +24,6 @@ const motionReducedBlock = `
   }
 }`;
 
-async function appendMotionReducedBlock(filePath) {
-  const content = await fs.readFile(filePath, 'utf-8');
-  if (content.includes('--pine-motion-duration-fast') && !content.includes('prefers-reduced-motion')) {
-    await fs.writeFile(filePath, content.trimEnd() + motionReducedBlock + '\n');
-  }
-}
-
 // Custom format for component CSS variables with :host selector
 StyleDictionary.registerFormat({
   name: 'css/variables-host',
@@ -257,6 +250,10 @@ StyleDictionary.registerFormat({
       }
     }
 
+    if (options.appendMotionReduced) {
+      output += motionReducedBlock + '\n';
+    }
+
     return output;
   }
 });
@@ -345,7 +342,8 @@ async function run() {
             options: {
               outputReferences: true,
               prefix: 'pine',
-              mode: 'light'
+              mode: 'light',
+              appendMotionReduced: true
             }
           }
         ],
@@ -564,7 +562,8 @@ async function run() {
             options: {
               outputReferences: true,
               prefix: 'pine',
-              mode: mode
+              mode: mode,
+              appendMotionReduced: mode === 'light'
             }
           }],
           prefix: 'pine'
@@ -664,7 +663,6 @@ async function run() {
   // Build all platforms in order
   // Build light first to temp files, then dark to temp files, then combine
   await coreSdLight.buildAllPlatforms();
-  await appendMotionReducedBlock(resolve(buildPath, 'base/_core.scss'));
   await semanticSdLight.buildAllPlatforms();
   await semanticSdDark.buildAllPlatforms();
 
@@ -794,7 +792,6 @@ async function run() {
         ? header + fontFaceBlock + body + siteBrandOverride + '\n'
         : combined;
       await fs.writeFile(finalPath, finalContent);
-      await appendMotionReducedBlock(finalPath);
       await fs.unlink(darkPath);
     } catch (e) {
       console.warn(`Could not combine ${brandName} files:`, e.message);

--- a/packages/styles/src/tokens/brand/core.json
+++ b/packages/styles/src/tokens/brand/core.json
@@ -1132,6 +1132,38 @@
       "type": "letterSpacing"
     }
   },
+  "motion-duration": {
+    "none": {
+      "value": "0ms",
+      "type": "other"
+    },
+    "fast": {
+      "value": "120ms",
+      "type": "other"
+    },
+    "base": {
+      "value": "200ms",
+      "type": "other"
+    },
+    "slow": {
+      "value": "300ms",
+      "type": "other"
+    }
+  },
+  "motion-easing": {
+    "out": {
+      "value": "cubic-bezier(0, 0, 0.2, 1)",
+      "type": "other"
+    },
+    "in": {
+      "value": "cubic-bezier(0.4, 0, 1, 1)",
+      "type": "other"
+    },
+    "in-out": {
+      "value": "cubic-bezier(0.4, 0, 0.2, 1)",
+      "type": "other"
+    }
+  },
   "z-index": {
     "0": {
       "value": "0",


### PR DESCRIPTION
## Summary
- Add core motion tokens (`--pine-motion-duration-*`, `--pine-motion-easing-*`) to `@kajabi-ui/styles`, matching the Pine motion guide contract
- Include `--pine-motion-duration-none` (`0ms`) for intentionally instant transitions
- Append `prefers-reduced-motion: reduce` overrides in generated stylesheets so duration tokens collapse to `0ms` automatically

## Test plan
- [x] `npx nx build @kajabi-ui/styles` succeeds
- [ ] Verify `pine.css` and `kajabi_products.css` expose motion variables
- [ ] After release, Pine can remove `libs/core/src/global/styles/_motion.scss` in a follow-up PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive token and generated CSS changes with accessibility-friendly duration overrides; no runtime logic or security-sensitive paths.
> 
> **Overview**
> Adds **core motion design tokens** to `@kajabi-ui/styles`: `--pine-motion-duration-*` (`none`, `fast`, `base`, `slow`) and `--pine-motion-easing-*` (`in`, `out`, `in-out`) in `brand/core.json`, emitted into generated `base/_core.scss` and brand bundles (`pine`, `kajabi_products`).
> 
> The Style Dictionary pipeline now **appends a `prefers-reduced-motion: reduce` block** on light outputs (`appendMotionReduced`) so `fast`/`base`/`slow` durations resolve to `0ms` for anything using those CSS variables—`none` stays instant by design.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 349dcbe3decdeafe8053ead3c58f78aa791f8f9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->