### PR TITLE
fix(release): add publish-only workflow and npm auth for release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,11 @@ on:
           - premajor
           - prerelease
 
+      publish_only:
+        type: boolean
+        description: Publish the current version on disk without bumping version or creating a release.
+        default: false
+
 jobs:
   release:
     permissions:
@@ -104,16 +109,24 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Publish only
+        if: ${{ inputs.publish_only }}
+        run: npx nx release publish --yes
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
+
       - name: Release
-        if: ${{ inputs.version == '' }}
+        if: ${{ !inputs.publish_only && inputs.version == '' }}
         run: npx nx release --yes
         env:
           GH_TOKEN: ${{ secrets.KAJABI_CI_GH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
         ### Steps below are used for releasing a specified version type (major, minor, patch, etc.)
       - name: Release with Input Version
-        if: ${{ inputs.version != '' }}
+        if: ${{ !inputs.publish_only && inputs.version != '' }}
         run: npx nx release ${{ github.event.inputs.version }} --preid ${{ inputs.preid }} --yes
         env:
           GH_TOKEN: ${{ secrets.KAJABI_CI_GH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Publish only
         if: ${{ inputs.publish_only }}
-        run: npx nx release publish --yes
+        run: npx nx release publish --tag ${{ inputs.tag }} --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,8 +111,9 @@ jobs:
 
       - name: Publish only
         if: ${{ inputs.publish_only }}
-        run: npx nx release publish --tag ${{ inputs.tag }} --yes
+        run: npx nx release publish --tag "$TAG" --yes
         env:
+          TAG: ${{ inputs.tag }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 


### PR DESCRIPTION
## Summary
- Adds a **Publish only** workflow dispatch option to republish the current version on disk without bumping semver or creating a GitHub release
- Passes `NODE_AUTH_TOKEN` to the default Release step so npm publish auth matches the versioned release path

This was used to republish `@kajabi-ui/styles@1.3.0` after the May 29 release tagged git but failed npm publish.

## Test plan
- [x] Ran **DS Tokens Release** with **Publish only** checked on `fix/republish-1.3.0`
- [x] Verified `npm view @kajabi-ui/styles version` returns `1.3.0`
- [ ] Merge to `main` so publish-only is available from the default branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes to the release workflow; no application runtime or security surface changes beyond existing npm publish credentials.
> 
> **Overview**
> Adds a **Publish only** `workflow_dispatch` flag so maintainers can run `nx release publish` for the version already in the repo—no semver bump and no GitHub release—using the selected npm dist-tag.
> 
> When **Publish only** is set, the normal **Release** / **Release with Input Version** steps are skipped. The default **Release** step (empty version) now also sets `NODE_AUTH_TOKEN`, aligning npm auth with the versioned release path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8273ffdd735a5af41d8eaf703125037013967bb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->