### PR TITLE
feat: add color-background-overlay token for modal surfaces

### DIFF
--- a/packages/styles/_generated/base/_semantic.scss
+++ b/packages/styles/_generated/base/_semantic.scss
@@ -21,6 +21,7 @@
   --pine-color-background-container-hover: var(--pine-color-grey-050);
   --pine-color-background-inset: var(--pine-color-grey-200);
   --pine-color-background-inset-emphasized: var(--pine-color-grey-300);
+  --pine-color-background-overlay: var(--pine-color-white);
   --pine-color-border: var(--pine-color-grey-300);
   --pine-color-border-hover: var(--pine-color-grey-400);
   --pine-color-border-disabled: var(--pine-color-grey-200);
@@ -208,6 +209,7 @@
   --pine-color-background-container-hover: var(--pine-color-grey-950);
   --pine-color-background-inset: var(--pine-color-grey-700);
   --pine-color-background-inset-emphasized: var(--pine-color-grey-600);
+  --pine-color-background-overlay: var(--pine-color-grey-900);
   --pine-color-border: var(--pine-color-grey-600);
   --pine-color-border-hover: var(--pine-color-grey-500);
   --pine-color-border-disabled: var(--pine-color-grey-700);

--- a/packages/styles/_generated/kajabi_products/kajabi_products.scss
+++ b/packages/styles/_generated/kajabi_products/kajabi_products.scss
@@ -235,6 +235,7 @@
   --pine-color-background-container-hover: var(--pine-color-grey-050);
   --pine-color-background-inset: var(--pine-color-grey-200);
   --pine-color-background-inset-emphasized: var(--pine-color-grey-300);
+  --pine-color-background-overlay: var(--pine-color-white);
   --pine-color-border: var(--pine-color-grey-300);
   --pine-color-border-hover: var(--pine-color-grey-400);
   --pine-color-border-disabled: var(--pine-color-grey-200);
@@ -517,6 +518,7 @@
   --pine-color-background-container-hover: var(--pine-color-grey-950);
   --pine-color-background-inset: var(--pine-color-grey-700);
   --pine-color-background-inset-emphasized: var(--pine-color-grey-600);
+  --pine-color-background-overlay: var(--pine-color-grey-900);
   --pine-color-border: var(--pine-color-grey-600);
   --pine-color-border-hover: var(--pine-color-grey-500);
   --pine-color-border-disabled: var(--pine-color-grey-700);

--- a/packages/styles/_generated/pine/pine.scss
+++ b/packages/styles/_generated/pine/pine.scss
@@ -201,6 +201,7 @@
   --pine-color-background-container-hover: var(--pine-color-grey-050);
   --pine-color-background-inset: var(--pine-color-grey-200);
   --pine-color-background-inset-emphasized: var(--pine-color-grey-300);
+  --pine-color-background-overlay: var(--pine-color-white);
   --pine-color-border: var(--pine-color-grey-300);
   --pine-color-border-hover: var(--pine-color-grey-400);
   --pine-color-border-disabled: var(--pine-color-grey-200);
@@ -483,6 +484,7 @@
   --pine-color-background-container-hover: var(--pine-color-grey-950);
   --pine-color-background-inset: var(--pine-color-grey-700);
   --pine-color-background-inset-emphasized: var(--pine-color-grey-600);
+  --pine-color-background-overlay: var(--pine-color-grey-900);
   --pine-color-border: var(--pine-color-grey-600);
   --pine-color-border-hover: var(--pine-color-grey-500);
   --pine-color-border-disabled: var(--pine-color-grey-700);

--- a/packages/styles/src/tokens/semantic/dark.json
+++ b/packages/styles/src/tokens/semantic/dark.json
@@ -98,6 +98,11 @@
           "value": "{color.grey.600}",
           "type": "color"
         }
+      },
+      "overlay": {
+        "value": "{color.grey.900}",
+        "type": "color",
+        "description": "Modal and overlay panel background"
       }
     },
     "border": {

--- a/packages/styles/src/tokens/semantic/light.json
+++ b/packages/styles/src/tokens/semantic/light.json
@@ -132,6 +132,11 @@
           "value": "{color.grey.300}",
           "type": "color"
         }
+      },
+      "overlay": {
+        "value": "{color.white}",
+        "type": "color",
+        "description": "Modal and overlay panel background"
       }
     },
     "border": {


### PR DESCRIPTION
## Summary
- Adds semantic `color.background.overlay` for modal and overlay panel backgrounds
- Light mode maps to `white` (`--pine-color-background-overlay`)
- Dark mode maps to `grey-900` (not black), matching modal surface intent

## Test plan
- [ ] Run `npm run generate` in `packages/styles` and confirm output includes `--pine-color-background-overlay` in light and dark blocks
- [ ] Import `@kajabi-ui/styles/pine/pine.scss` and verify light theme resolves overlay to white and dark theme to grey-900
- [ ] Wire Pine modal components to `var(--pine-color-background-overlay)` after package release

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive design-token and generated CSS only; no runtime logic or existing token overrides.
> 
> **Overview**
> Introduces a new semantic **`color.background.overlay`** token for modal and overlay panel surfaces, wired through **`light.json`** and **`dark.json`** and emitted as **`--pine-color-background-overlay`** in generated SCSS (`base/_semantic`, `pine`, `kajabi_products`).
> 
> **Light** maps to white; **dark** maps to grey-900 (not black), so modal panels stay visually distinct from container/black backgrounds. Downstream UI can adopt **`var(--pine-color-background-overlay)`** after the styles package ships; this PR does not change component styles yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 789de7dace5ced4a1eb2d650fa662f0b24d646d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->