### PR TITLE
ci: gate builds on generated token output drift

### DIFF
--- a/.github/workflows/actions/build-styles/action.yml
+++ b/.github/workflows/actions/build-styles/action.yml
@@ -49,3 +49,18 @@ runs:
     - name: Build Styles
       run: npx nx run @kajabi-ui/styles:build
       shell: bash
+
+    # Golden-output gate: the committed files in packages/styles/_generated are the
+    # source of truth consumed by Pine and other apps. The build regenerates them, so
+    # any drift between a fresh build and what's committed means the generated tokens
+    # were not regenerated/committed after a source or transform change. Fail loudly
+    # rather than letting a silent output regression ship downstream.
+    - name: Verify generated tokens are in sync
+      shell: bash
+      run: |
+        if ! git diff --exit-code -- packages/styles/_generated; then
+          echo "::error::Generated token output in packages/styles/_generated is out of sync with the token source."
+          echo "A fresh build produced different output than what is committed."
+          echo "Fix: run 'npx nx run @kajabi-ui/styles:build' and commit the changes under packages/styles/_generated."
+          exit 1
+        fi


### PR DESCRIPTION
## Problem

`ds-tokens` has no tests. CI runs lint and a build, but nothing verifies that the **generated output** — the files in `packages/styles/_generated/` that Pine and other apps consume — actually matches the token source.

That output is the repo's real contract. An 802-line transform (`src/lib/transform/index.js`) plus the JSON token source can drift from the committed `_generated/` files with zero signal: a bad alias, a dropped token, a broken reference, or a malformed block can ship to every downstream consumer and only surface when something renders wrong in production.

## Change

Adds one step to the `build-styles` composite action, right after the build (which regenerates `_generated/`):

```bash
git diff --exit-code -- packages/styles/_generated
```

The committed `_generated/` files are treated as **golden files**. If a fresh build produces output that differs from what's committed, the build fails with an actionable message telling the contributor to rebuild and commit. This catches the "changed the source/transform, didn't regenerate" and "transform produced unexpected output" cases before they reach consumers.

No new dependencies, no test framework — it leans on the fact that generated output is already committed and that `generate` is deterministic.

## Verification (local)

- **No false positive:** on a clean `main`, `nx run @kajabi-ui/styles:build` then `git diff --exit-code _generated` passes (output is deterministic and in sync).
- **True positive:** changing `color.white` source value `#FFF` → `#FFE` propagates to `_generated/base/_core.scss` (`--pine-color-white: #ffffff` → `#ffffee`) and the gate trips as expected. Restoring the source returns the tree to clean.

## Follow-up (not in this PR)

This is the change-safety floor. A natural next layer is a Vitest pass asserting *semantic* invariants (all references resolve, critical tokens present, no orphaned aliases) rather than just byte-for-byte output equality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only guard on generated artifacts; no runtime or application logic changes.
> 
> **Overview**
> Adds a **golden-output check** to the `build-styles` composite action immediately after `@kajabi-ui/styles:build`. CI runs `git diff --exit-code` on `packages/styles/_generated` and **fails** if a fresh build changes anything that isn’t committed.
> 
> This blocks shipping token source or transform updates without regenerating and committing `_generated/` (the files Pine and other apps consume). On failure, the workflow prints an error with the fix: run the Nx styles build and commit under `packages/styles/_generated`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7bfa825c3867b436205b9a7a45647da0baa6b10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->