### PR TITLE
fix: emit literal font-family keywords in typography tokens

### DIFF
--- a/packages/styles/_generated/base/_semantic.scss
+++ b/packages/styles/_generated/base/_semantic.scss
@@ -177,14 +177,14 @@
   --pine-typography-heading-caption: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-caption)/var(--pine-line-height-heading) var(--pine-font-family-inter);
   --pine-typography-body: var(--pine-font-weight-regular) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-monospace);
+  --pine-typography-body-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) monospace;
   --pine-typography-body-semi-bold: var(--pine-font-weight-semi-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-faire-sprig);
   --pine-typography-body-sm: var(--pine-font-weight-regular) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-sm-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-sm-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-monospace);
+  --pine-typography-body-sm-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) monospace;
   --pine-typography-body-sm-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-sm-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-sm-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-faire-sprig);

--- a/packages/styles/_generated/kajabi_products/kajabi_products.scss
+++ b/packages/styles/_generated/kajabi_products/kajabi_products.scss
@@ -477,14 +477,14 @@
   --pine-typography-heading-caption: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-caption)/var(--pine-line-height-heading) var(--pine-font-family-inter);
   --pine-typography-body: var(--pine-font-weight-regular) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-monospace);
+  --pine-typography-body-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) monospace;
   --pine-typography-body-semi-bold: var(--pine-font-weight-semi-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-faire-sprig);
   --pine-typography-body-sm: var(--pine-font-weight-regular) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-sm-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-sm-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-monospace);
+  --pine-typography-body-sm-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) monospace;
   --pine-typography-body-sm-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-sm-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-sm-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-faire-sprig);

--- a/packages/styles/_generated/pine/pine.scss
+++ b/packages/styles/_generated/pine/pine.scss
@@ -443,14 +443,14 @@
   --pine-typography-heading-caption: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-caption)/var(--pine-line-height-heading) var(--pine-font-family-inter);
   --pine-typography-body: var(--pine-font-weight-regular) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-monospace);
+  --pine-typography-body-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) monospace;
   --pine-typography-body-semi-bold: var(--pine-font-weight-semi-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-faire-sprig);
   --pine-typography-body-sm: var(--pine-font-weight-regular) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-sm-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-sm-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-monospace);
+  --pine-typography-body-sm-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) monospace;
   --pine-typography-body-sm-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-sm-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
   --pine-typography-body-sm-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-faire-sprig);

--- a/packages/styles/src/lib/transform/index.js
+++ b/packages/styles/src/lib/transform/index.js
@@ -103,6 +103,12 @@ StyleDictionary.registerFormat({
       return `var(--${prefix}-${varName})`;
     };
 
+    // Helper for composite-token parts (typography): a `{ref}` becomes a var(),
+    // but a literal CSS value (e.g. fontFamily "monospace") is emitted as-is.
+    // Without this, literals get wrapped into bogus refs like var(--pine-monospace).
+    const partToValue = (raw, prefix) =>
+      /\{.+\}/.test(raw) ? refToVar(raw.replace(/[{}]/g, ''), prefix) : raw;
+
     // Helper to convert token references to CSS variable references
     const formatTokenValue = (token, prefix) => {
       const originalValue = token.original?.value || token.value;
@@ -114,24 +120,20 @@ StyleDictionary.registerFormat({
 
         // fontWeight
         if (originalValue.fontWeight) {
-          const fwRef = originalValue.fontWeight.replace(/[{}]/g, '');
-          parts.push(refToVar(fwRef, prefix));
+          parts.push(partToValue(originalValue.fontWeight, prefix));
         }
 
         // fontSize / lineHeight
         if (originalValue.fontSize && originalValue.lineHeight) {
-          const fsRef = originalValue.fontSize.replace(/[{}]/g, '');
-          const lhRef = originalValue.lineHeight.replace(/[{}]/g, '').replace(/\s*\*\s*100%/, '');
-          parts.push(`${refToVar(fsRef, prefix)}/${refToVar(lhRef, prefix)}`);
+          const lineHeight = originalValue.lineHeight.replace(/\s*\*\s*100%/, '');
+          parts.push(`${partToValue(originalValue.fontSize, prefix)}/${partToValue(lineHeight, prefix)}`);
         } else if (originalValue.fontSize) {
-          const fsRef = originalValue.fontSize.replace(/[{}]/g, '');
-          parts.push(refToVar(fsRef, prefix));
+          parts.push(partToValue(originalValue.fontSize, prefix));
         }
 
         // fontFamily
         if (originalValue.fontFamily) {
-          const ffRef = originalValue.fontFamily.replace(/[{}]/g, '');
-          parts.push(refToVar(ffRef, prefix));
+          parts.push(partToValue(originalValue.fontFamily, prefix));
         }
 
         return parts.join(' ');


### PR DESCRIPTION
## The bug

`--pine-typography-body-mono` and `--pine-typography-body-sm-mono` shipped with a reference to a token that does not exist:

```scss
--pine-typography-body-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-monospace);
```

`--pine-monospace` is never defined, so the `font-family` segment resolves to nothing — monospace typography tokens are effectively broken for every consumer.

Surfaced by the referential-integrity test in #46 (it's the lone `KNOWN_DANGLING` entry there).

## Root cause

The typography shorthand builder in `src/lib/transform/index.js` assumed every part is a token reference and piped each through `refToVar()`, which wraps its input in `var(--pine-…)`. That's correct for references like `"{font-family.inter}"` → `var(--pine-font-family-inter)`. But the `mono` token's source uses a literal CSS keyword:

```jsonc
"mono": { "value": { "fontFamily": "monospace", ... } }
```

`"monospace"` has no braces, so wrapping it produced the bogus `var(--pine-monospace)`.

## Fix

Add a small reference-aware helper and route the typography parts through it:

```js
const partToValue = (raw, prefix) =>
  /\{.+\}/.test(raw) ? refToVar(raw.replace(/[{}]/g, ''), prefix) : raw;
```

A `{ref}` still becomes a `var()`; a literal (e.g. `monospace`, and future `sans-serif`/`serif`) is emitted verbatim. This fixes the whole class of bug, not just the one token.

## Output diff (regenerated)

Exactly 6 lines across 3 files — only the mono tokens change; every other token is byte-for-byte identical:

```diff
- ... var(--pine-monospace);
+ ... monospace;
```

## Verification

- `npm run generate` → only the 6 mono lines change.
- Referential-integrity scan over `_generated/`: **0 dangling references** (was 1).
- `grep pine-monospace _generated/` → gone.

## Coordination with #46

This is the dedicated fix referenced by #46. **Merge order:** once this lands on `main`, #46 should be rebased and the `--pine-monospace` entry dropped from `KNOWN_DANGLING` — its referential-integrity test will then pass with no allowlist entry. (If #46 merges first, its golden-output gate / committed `_generated` will conflict with this PR's regenerated output and need a rebase regardless.) Happy to handle that rebase.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped token-build fix and six-line generated CSS changes; restores intended monospace styling without touching auth or business logic.
> 
> **Overview**
> Fixes broken **mono** typography CSS variables that incorrectly referenced a non-existent `--pine-monospace` token.
> 
> The Style Dictionary typography formatter in `packages/styles/src/lib/transform/index.js` now uses a **`partToValue`** helper: braced token references still become `var(--pine-…)`, while literal values (e.g. `fontFamily: "monospace"`) are written verbatim into the shorthand. Typography **fontWeight**, **fontSize**, **lineHeight**, and **fontFamily** segments all go through this path.
> 
> Regenerated `_generated` output updates only **`--pine-typography-body-mono`** and **`--pine-typography-body-sm-mono`** in `base/_semantic.scss`, `pine/pine.scss`, and `kajabi_products/kajabi_products.scss` (`var(--pine-monospace)` → `monospace`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43e7993dba811bd4ee30b08ac16533bb3c8295d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->