### PR TITLE
docs: add CONTRIBUTING and versioning policy for token contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,15 @@ prefixed `--pine-*`.
 
 ## Making a change
 
+> **Authoring in Figma (Token Studio).** These source JSON files are the
+> [Tokens Studio](https://tokens.studio/) export format — Figma is the design
+> source of truth, and `$themes.json` / `$metadata.json` are Token Studio's own
+> files. Token changes often originate in Figma and are synced here; editing the
+> JSON directly (below) is the code side of the same files. For a change that
+> should round-trip to design, coordinate with @Kajabi/dss-devs so Figma and the
+> repo don't diverge. See [Using Token Studio](./packages/styles/README.md#using-token-studio)
+> and [ADR-0001](./docs/adr/0001-three-tier-token-architecture.md).
+
 1. **Edit the source JSON**, not the generated output. Pick the right tier:
    - new raw value (a color, a spacing step) → `brand/core.json`
    - a role (text, background, border, etc.) → `semantic/light.json` + `semantic/dark.json`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,120 @@
+# Contributing to ds-tokens
+
+`ds-tokens` produces `@kajabi-ui/styles` — the design tokens that Pine and every
+consuming Kajabi app build on. Because the published output is a **contract many
+teams depend on**, this guide covers not just *how* to change a token but how to
+do it without breaking downstream consumers. For the versioning and
+breaking-change policy, see [VERSIONING.md](./VERSIONING.md).
+
+## Prerequisites
+
+- Node.js `22` (see [`.nvmrc`](./.nvmrc)) — `nvm use` will pick it up
+- npm (the repo uses npm workspaces; do not use yarn despite occasional mentions)
+
+## Setup
+
+```bash
+git clone https://github.com/Kajabi/ds-tokens.git
+cd ds-tokens
+npm install
+npx nx build @kajabi-ui/styles   # generates token output
+```
+
+## How the repo is laid out
+
+Nx monorepo with a single published package, `packages/styles` (`@kajabi-ui/styles`).
+
+```
+packages/styles/
+  src/
+    tokens/                 # SOURCE OF TRUTH (Tokens Studio JSON)
+      brand/core.json       #   primitive tier — raw palette, spacing, shadows, type
+      semantic/             #   semantic tier — light.json / dark.json (roles)
+      components/           #   component tier — alert, chip, input, select (+ -dark)
+      kajabi_products/      #   brand theme overrides (light/dark)
+      $themes.json          #   Tokens Studio theme/set definitions
+      $metadata.json        #   Tokens Studio metadata
+    lib/transform/          # Style Dictionary build (JSON -> SCSS/CSS)
+  _generated/               # COMMITTED build output — the contract consumers read
+  dist/                     # build artifact (gitignored, published to npm)
+```
+
+Tokens flow **primitive → semantic → component**. Higher tiers reference lower
+ones (`{color.grey.900}`), never the reverse. Output custom properties are
+prefixed `--pine-*`.
+
+## Making a change
+
+1. **Edit the source JSON**, not the generated output. Pick the right tier:
+   - new raw value (a color, a spacing step) → `brand/core.json`
+   - a role (text, background, border, etc.) → `semantic/light.json` + `semantic/dark.json`
+   - a component-specific token → `components/*.json` (+ matching `-dark.json`)
+
+2. **Regenerate and commit the output.** `_generated/` is committed and is what
+   consumers read — it must always be in sync with the source:
+   ```bash
+   npx nx build @kajabi-ui/styles
+   git add packages/styles/src packages/styles/_generated
+   ```
+   A PR that changes source but not `_generated/` (or vice versa) is a bug.
+   Reviewers check the regenerated diff.
+
+3. **Lint:**
+   ```bash
+   npx nx affected --target=lint
+   ```
+
+4. **Check the impact on consumers.** Before opening the PR, classify your change
+   against [VERSIONING.md](./VERSIONING.md): is it additive (minor), a value tweak
+   (patch), or **breaking** (removing/renaming a token, changing what a semantic
+   token means)? Breaking changes need a migration note — see below.
+
+## Branches & commits
+
+**Branch names** are enforced by a pre-push hook. Use `type/short-description`
+where `type` is one of:
+
+```
+chore  ci  docs  feat  fix  hotfix  perf  refactor  revert  style  test
+```
+
+> ⚠️ `feature/…` is **not** valid (the hook rejects it) — use `feat/…`.
+
+**Commits** follow [Conventional Commits](https://www.conventionalcommits.org/)
+and are enforced by commitlint. The type is not cosmetic — it **drives the next
+release version** (see [VERSIONING.md](./VERSIONING.md)):
+
+| Commit | Result |
+| --- | --- |
+| `feat: …` | minor bump |
+| `fix: …` | patch bump |
+| `feat!:` / `BREAKING CHANGE:` footer | major bump |
+| `docs:` / `chore:` / `style:` / `refactor:` | no release on its own |
+
+Keep messages to a single line; scope when it helps (`feat(chip): …`).
+
+## Pull requests
+
+- Open against `main`. `@Kajabi/dss-devs` (via `CODEOWNERS`) reviews token changes.
+- CI runs build + lint across the Node matrix. Regenerating `_generated/` is the
+  contributor's responsibility (reviewers check the regenerated diff).
+- For any **breaking change**, the PR description must include a **Migration**
+  section: what was removed/renamed, the replacement, and a before/after snippet.
+  This text becomes the basis for the changelog migration note.
+
+## Git hooks (lefthook)
+
+Run automatically; don't skip them:
+
+- **pre-commit** — stylelint + eslint on staged files
+- **commit-msg** — commitlint (conventional commits)
+- **pre-push** — branch-name validation
+
+## Releasing
+
+Releases are cut by the maintainers via the `release` workflow (manual dispatch),
+not automatically on merge. Versioning is Nx Release driven by the conventional
+commits since the last release; publishing goes to npm with provenance, pushed by
+the `kajabi-github-actions` bot using `KAJABI_CI_GH_TOKEN`. The `CHANGELOG.md` is
+generated from commit history. See [VERSIONING.md](./VERSIONING.md) for the full
+policy.

--- a/README.md
+++ b/README.md
@@ -66,51 +66,18 @@ npx nx graph
 
 ## Contributing
 
-We welcome contributions from the team! Here's how to get started:
+We welcome contributions from the team. Because `@kajabi-ui/styles` is a contract
+that Pine and downstream apps depend on, please read:
 
-### Contribution Workflow
+- **[CONTRIBUTING.md](./CONTRIBUTING.md)** — setup, how to add or change a token,
+  regenerating output, branch/commit conventions, and the PR process.
+- **[VERSIONING.md](./VERSIONING.md)** — what counts as a breaking change, the
+  deprecation policy, and how releases are cut.
 
-1. **Fork & Clone**: Fork the repository on GitHub, then clone your fork locally.
-   ```bash
-   # Fork the repo on GitHub first, then:
-   git clone https://github.com/YOUR-USERNAME/ds-tokens.git
-   cd ds-tokens
-   ```
-
-2. **Create a Branch**: Create a new branch for your feature or bug fix.
-   ```bash
-   git checkout -b feature/your-feature-name
-   ```
-
-3. **Make Changes**: Implement your changes following our coding standards.
-
-4. **Lint Code**: Ensure your changes meet our code quality standards.
-   ```bash
-   npx nx affected --target=lint
-   ```
-
-5. **Commit Changes**: We follow [Conventional Commits](https://www.conventionalcommits.org/) standards for commit messages.
-   ```bash
-   git commit -m "feat: add new color token system"
-   git commit -m "fix: resolve color token inconsistency"
-   git commit -m "docs: update token documentation"
-   ```
-
-   Common types include: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, and `chore`.
-
-6. **Push Changes**: Push your branch to GitHub.
-   ```bash
-   git push origin feature/your-feature-name
-   ```
-
-7. **Create Pull Request**: Open a PR against the main branch and request reviews.
-
-### Development Guidelines
-
-- Follow the existing code style and conventions
-- Add tests for new features
-- Update documentation when necessary
-- Make sure all tests pass before submitting a PR
+Quick notes: changes follow [Conventional Commits](https://www.conventionalcommits.org/)
+(the commit type drives the release version), and branch names use a
+`type/description` form (`feat/…`, `fix/…`, etc. — `feature/…` is rejected by the
+branch-name hook).
 
 ## License
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,96 @@
+# Versioning & breaking-change policy
+
+`@kajabi-ui/styles` is consumed by Pine and many downstream apps that upgrade on
+their own schedule. The published token set is a **public contract**. This
+document defines what counts as a breaking change, how we deprecate, and how
+releases are cut, so consumers can upgrade with confidence.
+
+We follow [Semantic Versioning](https://semver.org/). The unit of the contract is
+the **set of emitted `--pine-*` custom properties** in `_generated/` (and the
+published `dist/`), not the internal source JSON.
+
+## What each version level means for tokens
+
+### MAJOR — breaking, requires a migration note
+A consumer pinned to the previous version could break. Includes:
+
+- **Removing** a token that was previously emitted.
+- **Renaming** a token (this is a remove + add — see deprecation below).
+- **Changing the meaning** of a semantic or component token such that consumers
+  must react — e.g. repointing `--pine-color-text-danger` to a non-danger color,
+  or changing a token's type (color → length).
+- **Changing the output structure/format** — selector strategy, file layout under
+  `_generated/`/`dist/`, the `--pine-` prefix, or the package's export paths.
+
+### MINOR — additive, backward compatible
+- **Adding** a new token, theme, or mode.
+- Adding a new output file or export that doesn't alter existing ones.
+
+### PATCH — value tweaks & internals
+- Adjusting a **primitive value** where the token's *meaning* is unchanged
+  (e.g. nudging a grey hex, fixing a shadow offset).
+- Transform/build fixes that correct output without changing the token set
+  (e.g. fixing a malformed reference).
+- Docs and tooling.
+
+### The grey area: value changes
+A color/spacing value change is **visually** impactful but not **API**-breaking —
+the token still exists and still means the same thing. We treat pure value changes
+as **patch/minor**, never major. But: if a value change is visually significant
+(a noticeable hue/contrast shift, a spacing scale change), **call it out
+explicitly in the PR and changelog** so consumers can decide whether to QA. Don't
+let a "patch" silently restyle every downstream app without a heads-up.
+
+When in doubt, size up, not down. Shipping a breaking change as a minor is far
+more expensive than an over-cautious major.
+
+## Deprecation — prefer it over removal
+
+Don't hard-remove or rename tokens in place. Instead:
+
+1. Keep the old token emitting. If renaming, point the old name at the new one so
+   it keeps resolving.
+2. Mark it deprecated in the PR description and `CHANGELOG.md`, naming the
+   replacement.
+3. Remove it only in a subsequent **major** release, with a migration note.
+
+This gives consumers a window to migrate on a version where their build still
+works, instead of breaking on upgrade.
+
+## Migration notes
+
+Every breaking change ships with a migration note (in the PR, carried into the
+changelog) containing:
+
+- what was removed/renamed/repointed,
+- the replacement token,
+- a before/after snippet.
+
+Example:
+
+```
+### Breaking
+- Renamed `--pine-color-bg-overlay` → `--pine-color-background-overlay`.
+  Migrate: replace `var(--pine-color-bg-overlay)` with
+  `var(--pine-color-background-overlay)`. The old name is removed in this release.
+```
+
+## How releases are cut
+
+- **Trigger:** maintainers run the `release` workflow manually (`workflow_dispatch`)
+  — releases are intentional, not automatic on merge to `main`.
+- **Version:** Nx Release computes the bump from the Conventional Commits since the
+  last release (`feat` → minor, `fix` → patch, `feat!`/`BREAKING CHANGE:` → major).
+  Writing the right commit type is therefore part of getting the version right.
+- **Publish:** to npm with provenance. The version commit and tag are pushed by the
+  `kajabi-github-actions` bot via `KAJABI_CI_GH_TOKEN`, which is why branch
+  protection can stay on.
+- **Changelog:** `CHANGELOG.md` is generated from commit history; migration notes
+  for breaking changes should be reflected there.
+
+## Consumer guidance
+
+- Pin a real range (`^1.x`), not `*`. A wildcard pulls every change — including a
+  visually significant value tweak — with no gate.
+- Read the changelog before a minor/major bump; watch for migration and
+  "visually significant" notes.


### PR DESCRIPTION
## Why

From the engineering-health audit: `ds-tokens` scored lowest on **contract stability / documentation** (the highest-weighted dimension for shared infra). `@kajabi-ui/styles` is consumed by Pine and downstream apps that upgrade on their own schedule, but the repo had no written contract — no contribution guide for token changes, no definition of what counts as a breaking change, and no deprecation policy. The decisions lived only in maintainers' heads.

## What this adds

**`CONTRIBUTING.md`** — an authoritative contributor guide grounded in the repo's actual conventions:
- Setup (Node 22), repo layout, and the primitive → semantic → component token tiers.
- **How to make a token change**: edit source JSON (which tier for what), regenerate, and commit `_generated/` in the same PR (it's the committed contract consumers read).
- Branch/commit conventions, and how the conventional-commit type **drives the release version**.
- The lefthook hooks and the maintainer release flow (Nx Release, `KAJABI_CI_GH_TOKEN` bot, npm provenance).

**`VERSIONING.md`** — the contract policy:
- Precise SemVer rules **for tokens**: what's MAJOR (remove/rename/repoint/format change), MINOR (additive), PATCH (value tweak / internals).
- The honest grey area — pure value changes are patch/minor but must be flagged when visually significant.
- **Deprecation over removal** (keep the old token resolving, remove only in a major) and a migration-note format for breaking changes.
- Consumer guidance (pin a real range, not `*`).

**`README.md`** — replaced the thin, partly-inaccurate Contributing section with pointers to the above.

## Bug fixed along the way

The old README told contributors to branch `feature/your-feature-name` and `git push origin feature/…` — but the `validate-branch-name` pre-push hook only accepts `feat/` (not `feature/`), so following the README would fail the push. The new docs use the correct `feat/…` form and call out the footgun explicitly.

Docs-only; no code or token output changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no code, tokens, or build output affected.
> 
> **Overview**
> Documents the **@kajabi-ui/styles** contributor contract that was previously undocumented: new **`CONTRIBUTING.md`** (setup, token tiers, edit source + commit `_generated/`, Figma/Tokens Studio coordination, hooks, PR/migration expectations, release flow) and **`VERSIONING.md`** (SemVer for `--pine-*` output, deprecation-over-removal, migration notes, consumer pinning).
> 
> **`README.md`** drops the long fork/clone/`feature/…` workflow in favor of pointers to those guides and short notes on Conventional Commits and branch naming.
> 
> Fixes a **docs bug**: the old README recommended `feature/your-feature-name`, which conflicts with the **`validate-branch-name`** pre-push hook (`feat/…` only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b690bfcd09a667ba1b99a7ae74d4211cd6d8d7f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->