### PR TITLE
docs: add architecture decision records for token design

### DIFF
--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,31 @@
+# NNNN. Short title (imperative)
+
+- **Status:** Proposed | Accepted | Superseded by ADR-NNNN | Deprecated
+- **Date:** YYYY-MM-DD
+- **Deciders:** @github-handle, @github-handle
+
+## Context
+
+What pressure, constraint, or question prompted the decision? Keep it to the facts that mattered when the decision was made — don't editorialize.
+
+## Decision
+
+What did we choose? State it as a single clear sentence first; expand if needed.
+
+## Consequences
+
+What do we accept by choosing this? Include both:
+
+- **Positive** — what gets easier or better.
+- **Negative / accepted costs** — what gets harder, what we lose, what risk we now own.
+
+## Alternatives considered
+
+Bullet the realistic options that were on the table and one-line each on why they lost. If an alternative was never seriously considered, leave it out.
+
+- **Option A** — rejected because …
+- **Option B** — rejected because …
+
+## References
+
+Links to PRs, issues, Linear tickets, Slack threads, prior art, or external docs.

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,8 +1,8 @@
 # NNNN. Short title (imperative)
 
-- **Status:** Proposed | Accepted | Superseded by ADR-NNNN | Deprecated
+- **Status:** Proposed | Accepted | Accepted (retrospective) | Superseded by ADR-NNNN | Deprecated
 - **Date:** YYYY-MM-DD
-- **Deciders:** @github-handle, @github-handle
+- **Maintainers:** @github-handle, @github-handle
 
 ## Context
 

--- a/docs/adr/0001-three-tier-token-architecture.md
+++ b/docs/adr/0001-three-tier-token-architecture.md
@@ -1,0 +1,45 @@
+# 0001. Three-tier tokens via Tokens Studio + Style Dictionary
+
+- **Status:** Accepted (retrospective)
+- **Date:** 2026-06-26
+- **Maintainers:** @Kajabi/dss-devs
+
+## Context
+
+`@kajabi-ui/styles` is consumed by Pine components and by non-Pine surfaces (Rails views, marketing pages, internal tooling) that all need consistent color, spacing, type, shadow, motion, and z-index values. The design source of truth lives in Figma via Tokens Studio. We needed a structure that (1) lets designers author in Figma and export deterministically, (2) separates raw values from their semantic intent so a re-skin doesn't touch every reference, and (3) emits CSS custom properties consumers can use directly.
+
+## Decision
+
+Author tokens as **Tokens Studio JSON** organized into three tiers, and transform them to CSS/SCSS/JSON with **Style Dictionary** (via `@tokens-studio/sd-transforms`):
+
+- **Primitive** (`src/tokens/brand/core.json`) — raw palette, spacing, shadow, type, motion, z-index.
+- **Semantic** (`src/tokens/semantic/`) — roles (`color.text.*`, `color.background.*`, …) that reference primitives.
+- **Component** (`src/tokens/components/`) — per-component tokens (alert, chip, input, select) that reference semantics.
+
+Higher tiers reference lower ones (`{color.grey.900}`); never the reverse. Output is prefixed `--pine-*`. The generated output is committed under `_generated/` and is the contract consumers read; `dist/` is the published artifact.
+
+## Consequences
+
+**Positive**
+
+- A re-skin changes primitives (or semantic mappings) without editing every consumer.
+- Figma ↔ code stays in sync through the Tokens Studio export format.
+- References resolve to real `var(--pine-*)` chains, so consumers get the cascade for free.
+
+**Negative / accepted costs**
+
+- The transform (`src/lib/transform/index.js`) carries real complexity — composite tokens (typography/border/shadow), theme permutation, and format registration all live there. It is the most fragile file in the repo.
+- A build step is required to go from source to output, and the generated output is committed, so contributors must regenerate and commit `_generated/` with every token change (see [CONTRIBUTING.md](../../CONTRIBUTING.md)).
+- Style Dictionary + Tokens Studio is a learning curve for new contributors.
+
+## Alternatives considered
+
+- **Hand-authored SCSS variables** — rejected: no Figma round-trip, error-prone, and no enforced tier separation.
+- **A single flat token list** — rejected: collapses primitive and semantic layers, so every value change ripples to consumers and re-skins are impossible.
+- **Generating straight to Pine on build (no published package)** — rejected: non-Pine consumers and the lint mappings still need a canonical, independently versioned source. See Pine ADR-0001 (externalized token package).
+
+## References
+
+- `packages/styles/src/tokens/` (source), `packages/styles/_generated/` (committed output)
+- `packages/styles/src/lib/transform/index.js` (Style Dictionary build)
+- Sibling repo: `Kajabi/pine` (consumer; ADR-0001 there documents the externalization from Pine's side)

--- a/docs/adr/0002-release-via-ci-bot-token.md
+++ b/docs/adr/0002-release-via-ci-bot-token.md
@@ -1,0 +1,38 @@
+# 0002. Release via CI bot token without disabling branch protection
+
+- **Status:** Accepted (retrospective)
+- **Date:** 2026-06-26
+- **Maintainers:** @Kajabi/dss-devs
+
+## Context
+
+Releasing `@kajabi-ui/styles` with Nx Release means pushing a version-bump commit and tag to `main`, then publishing to npm. `main` is protected, so the default `GITHUB_TOKEN` in CI cannot push the release commit — the release workflow was blocked. We needed automated, reproducible releases **without** weakening branch protection on `main`.
+
+## Decision
+
+The `release` workflow authenticates as the **`kajabi-github-actions` bot** using the `KAJABI_CI_GH_TOKEN` secret, which is permitted to bypass branch protection. The workflow re-points the git origin to that token's identity, lets `npx nx release` create and push the version commit/tag, and publishes to npm with provenance attestation. The release is triggered manually (`workflow_dispatch` / `workflow_call`), not automatically on merge.
+
+## Consequences
+
+**Positive**
+
+- Branch protection on `main` stays on for everyone, including CI.
+- Releases are reproducible and auditable — they run in CI, not from a maintainer's laptop.
+- npm provenance gives consumers a verifiable build origin.
+
+**Negative / accepted costs**
+
+- `KAJABI_CI_GH_TOKEN` is a privileged credential that must be maintained and rotated; its compromise would bypass branch protection.
+- Release commits appear under the bot identity rather than a human author.
+- Releases are a deliberate manual step — nothing ships just by merging to `main` (acceptable, and arguably desirable, for a contract package).
+
+## Alternatives considered
+
+- **Disable branch protection on `main`** — rejected: removes the guardrail for all changes to protect a once-per-release push.
+- **Use the default `GITHUB_TOKEN`** — rejected: it cannot push past branch protection, which is the whole problem.
+- **Release from a maintainer's machine** — rejected: not reproducible, not auditable, and ties releases to one person's environment.
+
+## References
+
+- `.github/workflows/release.yml` (origin re-point via `KAJABI_CI_GH_TOKEN`, `nx release`, npm publish with provenance)
+- [VERSIONING.md](../../VERSIONING.md) (how the version bump is computed from Conventional Commits)

--- a/docs/adr/0002-release-via-ci-bot-token.md
+++ b/docs/adr/0002-release-via-ci-bot-token.md
@@ -26,10 +26,14 @@ The `release` workflow authenticates as the **`kajabi-github-actions` bot** usin
 - Release commits appear under the bot identity rather than a human author.
 - Releases are a deliberate manual step — nothing ships just by merging to `main` (acceptable, and arguably desirable, for a contract package).
 
+### Security boundary
+
+The token is a shared Kajabi CI credential, not scoped to this repo, and is only consumed by the `release` workflow. Governance of it — repository/scope, the branch-protection bypass allowance, rotation, and revocation — lives with the team that owns `.github/` here: **`@kajabi/production-engineering`** (per [`CODEOWNERS`](../../.github/CODEOWNERS)), not the DSS team. This ADR records *why* the release path uses it; the operational controls are owned and documented on the platform side.
+
 ## Alternatives considered
 
 - **Disable branch protection on `main`** — rejected: removes the guardrail for all changes to protect a once-per-release push.
-- **Use the default `GITHUB_TOKEN`** — rejected: it cannot push past branch protection, which is the whole problem.
+- **Use the default `GITHUB_TOKEN`** — rejected: under this repo's current branch-protection rules it is not a permitted bypass actor, so it can't push the release commit. (GitHub *can* be configured to let Actions bypass protection, but that isn't — and shouldn't need to be — set up here.)
 - **Release from a maintainer's machine** — rejected: not reproducible, not auditable, and ties releases to one person's environment.
 
 ## References

--- a/docs/adr/0003-theming-via-token-sets.md
+++ b/docs/adr/0003-theming-via-token-sets.md
@@ -1,0 +1,46 @@
+# 0003. Theming via Tokens Studio sets and `[data-theme]` selectors
+
+- **Status:** Accepted (retrospective)
+- **Date:** 2026-06-26
+- **Maintainers:** @Kajabi/dss-devs
+
+## Context
+
+The token set must support light and dark modes and more than one brand (a Pine baseline and a `kajabi_products` brand) from a single source of truth, without shipping a separate package per theme or forcing consumers into runtime JavaScript theming.
+
+## Decision
+
+Model themes as **Tokens Studio theme sets** and permutate them at build time (`permutateThemes` from `@tokens-studio/sd-transforms`):
+
+- **Light/dark** are authored as parallel semantic sets (`semantic/light.json`, `semantic/dark.json`) and merged into one output file, with dark values emitted under a `[data-theme="dark"]` selector.
+- **Brands** are emitted as separate entry files (`pine.scss`, `kajabi_products.scss`), each containing its light + dark contexts.
+- A **site-brand override** (`[data-theme="site"]`) remaps accent tokens onto consumer-provided variables (e.g. `--kj-brand-primary`) so a Kajabi site can inject its own brand color.
+
+Consumers switch theme by setting `data-theme` on a root element; no JS token engine is required.
+
+## Consequences
+
+**Positive**
+
+- One source of truth produces every theme; consumers opt in via a single `data-theme` attribute.
+- Dark mode is "free" for any consumer using semantic tokens — the variable resolves differently under the dark selector. (This is what Pine ADR-0005 relies on for its per-component dark-mode rollout.)
+- Brand and site overrides compose through the cascade rather than through forked builds.
+
+**Negative / accepted costs**
+
+- Theme permutation adds the most intricate logic in the transform — filtering which sets belong to which output is where build bugs are most likely.
+- Each component that needs a distinct dark treatment requires a matching `*-dark.json` token set, so component-token additions come in light/dark pairs.
+- The set of supported themes is fixed at build time; a new brand means new source sets and a new output file, not a runtime config.
+
+## Alternatives considered
+
+- **A separate published package per theme** — rejected: duplicates the primitive layer and multiplies release overhead.
+- **Runtime JS theming (resolve tokens in the browser)** — rejected: tokens are CSS-first; the cascade + `data-theme` gives theming with zero runtime cost.
+- **Hardcoding dark values into each component downstream** — rejected: pushes theming responsibility onto every consumer and defeats the semantic layer (ADR-0001).
+
+## References
+
+- `packages/styles/src/tokens/$themes.json` (Tokens Studio set/theme definitions)
+- `packages/styles/src/tokens/semantic/{light,dark}.json`, `components/*-dark.json`
+- `packages/styles/_generated/{pine/pine.scss, kajabi_products/kajabi_products.scss}`
+- Sibling repo `Kajabi/pine` ADR-0005 (dark mode via semantic-token migration)

--- a/docs/adr/0004-cdn-distribution-via-jsdelivr.md
+++ b/docs/adr/0004-cdn-distribution-via-jsdelivr.md
@@ -1,0 +1,44 @@
+# 0004. Distribute tokens over the jsDelivr CDN as a first-class channel
+
+- **Status:** Accepted (retrospective)
+- **Date:** 2026-07-13
+- **Maintainers:** @Kajabi/dss-devs
+
+## Context
+
+`@kajabi-ui/styles` is published to npm, but a large share of consumption is from **server-rendered surfaces** (Rails views, marketing pages) that don't run an npm build for their styling. Those surfaces need the compiled token CSS at runtime via a plain `<link>`, without adding the package to a bundler graph.
+
+## Decision
+
+Treat the **jsDelivr CDN as a first-class distribution channel** alongside npm. Because the package is published to npm, jsDelivr serves its `dist/` automatically, and consumers load the compiled CSS directly:
+
+```html
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@kajabi-ui/styles@1.4.0/dist/kajabi_products/kajabi_products.css" />
+```
+
+This is documented in the package README and is how the primary consumer (kajabi-products) loads tokens at runtime — a **version-pinned** `<link>` in a shared partial, independent of its npm/yarn dependency graph.
+
+## Consequences
+
+**Positive**
+
+- Non-bundler surfaces get tokens with a single `<link>`; no build integration required.
+- The CDN URL is explicitly version-pinned, so runtime styling is reproducible and controlled at the point of use.
+- npm and CDN share one published artifact — no separate release path.
+
+**Negative / accepted costs**
+
+- **The runtime contract is the CDN URL, not the npm range.** This is the subtle one: pinning the npm dependency range does little for a consumer whose actual tokens come from a hardcoded CDN `<link>`. (This exact confusion led to a pinning PR being opened and then closed as a no-op — see references.) Version discipline has to happen at the `<link>`.
+- Pinned CDN links must be bumped by hand when a consumer wants a new token version; a stale link (e.g. an old `@1.0.8` lingering on one page) won't surface as a dependency warning.
+- Reliance on jsDelivr availability for runtime styling on those surfaces.
+
+## Alternatives considered
+
+- **npm-only distribution** — rejected: forces every consumer through a bundler, which the server-rendered surfaces don't have for CSS.
+- **Self-hosting the compiled CSS in each consumer** — rejected: duplicates the artifact and drifts from the published version.
+
+## References
+
+- `packages/styles/README.md` (documented jsDelivr usage)
+- kajabi-products `app/views/shared/_pine_assets.html.erb` (pinned CDN `<link>` for `@kajabi-ui/styles` + `@pine-ds/core`)
+- Pine PR #769 (closed) — pinning the npm range was a no-op precisely because the runtime contract is the CDN link

--- a/docs/adr/0005-committed-generated-output.md
+++ b/docs/adr/0005-committed-generated-output.md
@@ -1,0 +1,40 @@
+# 0005. Commit generated output as the versioned contract
+
+- **Status:** Accepted (retrospective)
+- **Date:** 2026-07-13
+- **Maintainers:** @Kajabi/dss-devs
+
+## Context
+
+Tokens are authored as JSON and transformed to SCSS/CSS by Style Dictionary (see ADR-0001). The transform output could be treated as a throwaway build artifact (gitignored, regenerated on demand). But the generated files *are* the thing consumers and downstream tooling read, and their diffs are the most human-legible signal of what a token change actually did.
+
+## Decision
+
+**Commit the generated output under `packages/styles/_generated/`** and treat it as the versioned contract. The committed files are the source of truth for what ships; every token/source change must regenerate and commit them in the same PR, so the diff shows the real effect on emitted CSS. (The published `dist/` remains gitignored — it's a pure build artifact.)
+
+Enforcement of the source↔output invariant is being added in CI: a drift gate that fails when a fresh build doesn't match the committed output (#45), and semantic-invariant tests over the committed output (#46).
+
+## Consequences
+
+**Positive**
+
+- PR reviewers see the actual emitted-CSS diff, not just a source change whose effect they'd have to imagine.
+- The committed output is a stable, inspectable contract; tooling (and the invariant tests) can read it without running a build.
+- Regressions in the transform surface as unexpected output diffs.
+
+**Negative / accepted costs**
+
+- Unusual convention — committing build output prompts "why is this checked in?" from newcomers (this ADR is the answer).
+- Contributors must remember to regenerate and commit `_generated/`; a source-only change is a bug. The CI drift gate (#45) exists to catch exactly that.
+- Larger, noisier diffs on token changes.
+
+## Alternatives considered
+
+- **Gitignore the generated output, regenerate on build** — rejected: hides the real impact of token changes from review and gives the invariant tests nothing committed to check.
+- **Snapshot only in tests, don't commit** — rejected: loses the human-legible per-PR diff that is most of the value.
+
+## References
+
+- `packages/styles/_generated/` (committed output), `packages/styles/dist/` (gitignored)
+- [CONTRIBUTING.md](../../CONTRIBUTING.md) (regenerate-and-commit workflow)
+- PRs #45 (drift gate), #46 (semantic-invariant tests)

--- a/docs/adr/0006-pine-prefix-namespace.md
+++ b/docs/adr/0006-pine-prefix-namespace.md
@@ -1,0 +1,38 @@
+# 0006. Emit a `--pine-*` namespace decoupled from the package name
+
+- **Status:** Accepted (retrospective)
+- **Date:** 2026-07-13
+- **Maintainers:** @Kajabi/dss-devs
+
+## Context
+
+The package is named `@kajabi-ui/styles`, but every custom property it emits is prefixed `--pine-*` (e.g. `--pine-color-background-overlay`). This mismatch reliably confuses newcomers: "why does a `kajabi-ui` package emit `pine` variables?"
+
+## Decision
+
+Emit all tokens under the **`pine` namespace** — the design system's name — independent of the npm package name. The prefix is set once as the Style Dictionary transform default (`options.prefix || 'pine'`) and applied uniformly across every output file.
+
+The package name (`@kajabi-ui/styles`, the broader Kajabi UI umbrella) and the CSS-variable namespace (`--pine-*`, the design system consumers actually reference) are deliberately **decoupled**.
+
+## Consequences
+
+**Positive**
+
+- Consumers reference a stable, design-system-branded namespace (`var(--pine-*)`) that won't churn if the package is renamed, re-homed, or re-scoped.
+- One short, collision-resistant prefix across all tiers and themes.
+- Aligns the variable namespace with Pine, the design system these tokens serve, rather than with packaging/distribution details.
+
+**Negative / accepted costs**
+
+- The package-name vs. prefix mismatch is a recurring "why?" (this ADR is the standing answer).
+- Renaming the prefix later would be a breaking change for every consumer, so `pine` is effectively permanent.
+
+## Alternatives considered
+
+- **Match the prefix to the package (`--kajabi-ui-*`)** — rejected: longer, ties the consumer-facing namespace to a packaging name that can change, and doesn't reflect the design system identity.
+- **No prefix / generic names (`--color-*`)** — rejected: high collision risk in consuming apps that also define their own custom properties.
+
+## References
+
+- `packages/styles/src/lib/transform/index.js` (`prefix` default of `pine`)
+- `packages/styles/_generated/` (uniform `--pine-*` output)

--- a/docs/adr/0007-lint-mappings-export.md
+++ b/docs/adr/0007-lint-mappings-export.md
@@ -1,0 +1,43 @@
+# 0007. Export `lint-mappings` as a cross-repo enforcement contract
+
+- **Status:** Accepted (retrospective)
+- **Date:** 2026-07-13
+- **Maintainers:** @Kajabi/dss-devs
+
+## Context
+
+Pine enforces "use semantic tokens, not hardcoded values" via custom lint plugins (see Pine ADR-0003). Those plugins need to know the mapping from raw values to core tokens and from core tokens to semantic roles — knowledge that lives here, in the token source. Duplicating that mapping in Pine would guarantee drift the moment a token changes.
+
+## Decision
+
+The build **generates and publishes a machine-readable mapping** so downstream linters consume it from a single source of truth. `scripts/generate-lint-mappings.js` emits `dist/tokens/pine-token-mappings.json` (hex→core, core→semantic), exposed via a dedicated package export:
+
+```json
+"./lint-mappings": "./dist/tokens/pine-token-mappings.json"
+```
+
+Pine's stylelint plugin imports `@kajabi-ui/styles/lint-mappings`, so lint enforcement stays in lockstep with the tokens it enforces against.
+
+## Consequences
+
+**Positive**
+
+- Lint rules and the token source can't drift — a token change updates the mappings that lint reads.
+- The mapping is a real, versioned part of the package contract, not a copy pasted into Pine.
+- Other consumers/tools can reuse the same export.
+
+**Negative / accepted costs**
+
+- `lint-mappings` is a public export: its shape is now a contract, and changing it can break Pine's lint build (belongs under the versioning policy like any other output).
+- A cross-repo coupling that isn't obvious from either repo alone — hence this ADR.
+
+## Alternatives considered
+
+- **Hardcode the mappings in Pine's lint plugin** — rejected: guarantees drift and puts token knowledge in the wrong repo.
+- **Derive mappings at lint time from the raw token JSON** — rejected: pushes transform logic into the consumer; the generated mapping is the clean interface.
+
+## References
+
+- `packages/styles/scripts/generate-lint-mappings.js` (generator)
+- `packages/styles/package.json` (`"./lint-mappings"` export)
+- Pine ADR-0003 (custom lint plugins that consume this mapping)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,37 @@
+# Architecture Decision Records
+
+This directory records significant decisions made about `ds-tokens` / `@kajabi-ui/styles` — *why* the repo looks the way it does, not just *what* it does.
+
+## Why ADRs?
+
+Several long-lived choices here are not obvious from reading the code: the three-tier token architecture, the Tokens Studio → Style Dictionary pipeline, the CI-bot release flow that works around branch protection, and the theming model. Without a record, the same decisions get re-litigated whenever a new contributor or stakeholder asks "why?". This mirrors the practice already in place in the sibling [Pine](https://github.com/Kajabi/pine) repo.
+
+## Format
+
+We use a lightweight [MADR](https://adr.github.io/madr/) variant. Each ADR is a single short Markdown file capturing:
+
+1. **Context** — what problem or pressure prompted the decision
+2. **Decision** — what we chose
+3. **Consequences** — what we accept by choosing it (good and bad)
+4. **Alternatives considered** — what we rejected and why
+
+See [`0000-template.md`](./0000-template.md).
+
+## Index
+
+| # | Title | Status |
+| --- | --- | --- |
+| [0001](./0001-three-tier-token-architecture.md) | Three-tier tokens via Tokens Studio + Style Dictionary | Accepted (retrospective) |
+| [0002](./0002-release-via-ci-bot-token.md) | Release via CI bot token without disabling branch protection | Accepted (retrospective) |
+| [0003](./0003-theming-via-token-sets.md) | Theming via Tokens Studio sets and `[data-theme]` selectors | Accepted (retrospective) |
+
+ADRs 0001–0003 were authored retrospectively to capture decisions already in the codebase. The **Maintainers** field on each names the team that owns the area today, not the original deciders.
+
+## When to write a new ADR
+
+Write one when a change:
+
+- Reshapes architecture (new tier, new transform pipeline, new output target)
+- Locks in a long-lived convention (naming, theming strategy, release mechanics)
+- Trades off something material (build complexity vs. design-tool fidelity, automation vs. branch protection)
+- Will be expensive to reverse later

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -14,6 +14,7 @@ We use a lightweight [MADR](https://adr.github.io/madr/) variant. Each ADR is a 
 2. **Decision** — what we chose
 3. **Consequences** — what we accept by choosing it (good and bad)
 4. **Alternatives considered** — what we rejected and why
+5. **References** (optional) — links to PRs, code, tickets, or prior art
 
 See [`0000-template.md`](./0000-template.md).
 
@@ -24,8 +25,12 @@ See [`0000-template.md`](./0000-template.md).
 | [0001](./0001-three-tier-token-architecture.md) | Three-tier tokens via Tokens Studio + Style Dictionary | Accepted (retrospective) |
 | [0002](./0002-release-via-ci-bot-token.md) | Release via CI bot token without disabling branch protection | Accepted (retrospective) |
 | [0003](./0003-theming-via-token-sets.md) | Theming via Tokens Studio sets and `[data-theme]` selectors | Accepted (retrospective) |
+| [0004](./0004-cdn-distribution-via-jsdelivr.md) | Distribute tokens over the jsDelivr CDN as a first-class channel | Accepted (retrospective) |
+| [0005](./0005-committed-generated-output.md) | Commit generated output as the versioned contract | Accepted (retrospective) |
+| [0006](./0006-pine-prefix-namespace.md) | Emit a `--pine-*` namespace decoupled from the package name | Accepted (retrospective) |
+| [0007](./0007-lint-mappings-export.md) | Export `lint-mappings` as a cross-repo enforcement contract | Accepted (retrospective) |
 
-ADRs 0001–0003 were authored retrospectively to capture decisions already in the codebase. The **Maintainers** field on each names the team that owns the area today, not the original deciders.
+ADRs 0001–0007 were authored retrospectively to capture decisions already in the codebase. The **Maintainers** field on each names the team that owns the area today, not the original deciders.
 
 ## When to write a new ADR
 


### PR DESCRIPTION
## Why

From the engineering-health audit: `ds-tokens` scored lowest on **governance** — Pine maintains 5 ADRs, `ds-tokens` had none. Several long-lived decisions here aren't obvious from the code and get re-litigated whenever someone asks "why is it built this way?". This captures them, matching the practice already in the sibling Pine repo.

## What this adds

`docs/adr/` with a README index, the MADR template (copied from Pine for consistency), and three retroactive ADRs:

- **0001 — Three-tier tokens via Tokens Studio + Style Dictionary.** Why primitive → semantic → component, the JSON-source/Style-Dictionary pipeline, and the committed `_generated/` output. Names the transform as the accepted complexity cost.
- **0002 — Release via CI bot token without disabling branch protection.** Why releases push through the `kajabi-github-actions` bot via `KAJABI_CI_GH_TOKEN` (the documented resolution to the branch-protection block), manual trigger, npm provenance.
- **0003 — Theming via Tokens Studio sets and `[data-theme]` selectors.** Why light/dark + brand themes come from one source via `permutateThemes`, emitted under `[data-theme]`, with the `[data-theme="site"]` brand override.

All three are marked **Accepted (retrospective)**; the Maintainers field names the owning team (`@Kajabi/dss-devs`), not the original deciders.

## Verification

Every factual claim was checked against the code, not memory:
- `[data-theme="dark"]`, `[data-theme="site"]`, `--kj-brand-primary` — confirmed in `_generated/`.
- `permutateThemes` — confirmed in `src/lib/transform/index.js`.
- origin re-point via `KAJABI_CI_GH_TOKEN` + `NPM_CONFIG_PROVENANCE: true` — confirmed in `release.yml`.
- Dropped a `prefers-color-scheme` claim during review — it's **not** in the output (dark is `[data-theme]`-only).

Docs-only; no code or token output changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown documentation only; no runtime, build, or token contract changes.
> 
> **Overview**
> Adds **`docs/adr/`** with a MADR-style template, README index, and **seven retrospective ADRs** documenting long-lived `@kajabi-ui/styles` / `ds-tokens` choices—aligned with the Pine repo’s governance practice.
> 
> The records cover the **three-tier Tokens Studio → Style Dictionary pipeline** and committed `_generated/` contract; **CI releases** via `KAJABI_CI_GH_TOKEN` without relaxing `main` protection; **theming** through token sets and `[data-theme]`; **jsDelivr** as a first-class CDN channel; **`--pine-*`** naming vs package name; and the **`lint-mappings`** export for cross-repo stylelint. No application code or token output changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9f2259df94771376c941024380a820ba82941c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->