### PR TITLE
chore: fix global CODEOWNERS pattern and route to current maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,9 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Global owners
+# NOTE: `*` matches all files. A bare `-` here previously matched only a file
+# literally named "-", so no code-owner review was actually enforced on general
+# files. Maintained by the two remaining DSS maintainers after the team wound down.
 
-- @Kajabi/dss-devs
+* @QuintonJason @pixelflips
 /.github/ @kajabi/production-engineering

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 # Global owners
 # NOTE: `*` matches all files. A bare `-` here previously matched only a file
 # literally named "-", so no code-owner review was actually enforced on general
-# files. Maintained by the two remaining DSS maintainers after the team wound down.
+# files. Routed to the @Kajabi/dss-devs team (still active, admin on this repo).
 
-* @QuintonJason @pixelflips
+* @Kajabi/dss-devs
 /.github/ @kajabi/production-engineering


### PR DESCRIPTION
## Why

Maintenance for the incoming-contributor phase now that the DSS team has wound down. Same fix as the sibling Pine PR.

1. **Latent bug:** the global-owners line was `- @Kajabi/dss-devs`. CODEOWNERS patterns are gitignore-style — `*` matches all files, a bare `-` matches only a file literally named `-`. It's syntactically valid (GitHub doesn't error), so it silently meant **no code-owner review was required on general files** — only `/.github/` (PE) had a working rule. Changed to `*`.
2. **Ownership:** `@Kajabi/dss-devs` is a dissolved team (2 remaining members). Routed to the two actual maintainers, @QuintonJason and @pixelflips, so the gate survives the team being deleted.

`/.github/ @kajabi/production-engineering` unchanged. Docs-adjacent, no code/token changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates GitHub review routing in CODEOWNERS; no application code or secrets.
> 
> **Overview**
> **Fixes a silent gap in required reviews:** the global owners line used `- @Kajabi/dss-devs`, which in CODEOWNERS only matches a file named `-`, not all paths—so most changes were not actually covered by that rule. It is now `* @Kajabi/dss-devs`, so `@Kajabi/dss-devs` is requested on general file changes.
> 
> Adds a short comment explaining the `*` vs `-` behavior. The `/.github/ @kajabi/production-engineering` rule is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 993ef8447a4b3429c63b8c703c9fa939916c018b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->