### PR TITLE
fix(styles): repoint focus-ring token from purple to neutral grey

### DIFF
--- a/packages/styles/_generated/base/_semantic.scss
+++ b/packages/styles/_generated/base/_semantic.scss
@@ -32,7 +32,7 @@
   --pine-color-danger: var(--pine-color-red-600);
   --pine-color-danger-disabled: var(--pine-color-red-100);
   --pine-color-danger-hover: var(--pine-color-red-700);
-  --pine-color-focus-ring: var(--pine-color-grey-300);
+  --pine-color-focus-ring: var(--pine-color-grey-600);
   --pine-color-focus-ring-danger: var(--pine-color-red-300);
   --pine-color-info: var(--pine-color-blue-500);
   --pine-color-info-disabled: var(--pine-color-blue-100);

--- a/packages/styles/_generated/base/_semantic.scss
+++ b/packages/styles/_generated/base/_semantic.scss
@@ -32,7 +32,7 @@
   --pine-color-danger: var(--pine-color-red-600);
   --pine-color-danger-disabled: var(--pine-color-red-100);
   --pine-color-danger-hover: var(--pine-color-red-700);
-  --pine-color-focus-ring: var(--pine-color-grey-500);
+  --pine-color-focus-ring: var(--pine-color-grey-400);
   --pine-color-focus-ring-danger: var(--pine-color-red-300);
   --pine-color-info: var(--pine-color-blue-500);
   --pine-color-info-disabled: var(--pine-color-blue-100);
@@ -220,7 +220,7 @@
   --pine-color-danger: var(--pine-color-red-600);
   --pine-color-danger-disabled: var(--pine-color-red-100);
   --pine-color-danger-hover: var(--pine-color-red-700);
-  --pine-color-focus-ring: var(--pine-color-grey-300);
+  --pine-color-focus-ring: var(--pine-color-grey-400);
   --pine-color-focus-ring-danger: var(--pine-color-red-300);
   --pine-color-info: var(--pine-color-blue-500);
   --pine-color-info-disabled: var(--pine-color-blue-100);

--- a/packages/styles/_generated/base/_semantic.scss
+++ b/packages/styles/_generated/base/_semantic.scss
@@ -32,7 +32,7 @@
   --pine-color-danger: var(--pine-color-red-600);
   --pine-color-danger-disabled: var(--pine-color-red-100);
   --pine-color-danger-hover: var(--pine-color-red-700);
-  --pine-color-focus-ring: var(--pine-color-grey-600);
+  --pine-color-focus-ring: var(--pine-color-grey-500);
   --pine-color-focus-ring-danger: var(--pine-color-red-300);
   --pine-color-info: var(--pine-color-blue-500);
   --pine-color-info-disabled: var(--pine-color-blue-100);

--- a/packages/styles/_generated/base/_semantic.scss
+++ b/packages/styles/_generated/base/_semantic.scss
@@ -220,7 +220,7 @@
   --pine-color-danger: var(--pine-color-red-600);
   --pine-color-danger-disabled: var(--pine-color-red-100);
   --pine-color-danger-hover: var(--pine-color-red-700);
-  --pine-color-focus-ring: var(--pine-color-grey-400);
+  --pine-color-focus-ring: var(--pine-color-grey-500);
   --pine-color-focus-ring-danger: var(--pine-color-red-300);
   --pine-color-info: var(--pine-color-blue-500);
   --pine-color-info-disabled: var(--pine-color-blue-100);

--- a/packages/styles/_generated/base/_semantic.scss
+++ b/packages/styles/_generated/base/_semantic.scss
@@ -32,7 +32,7 @@
   --pine-color-danger: var(--pine-color-red-600);
   --pine-color-danger-disabled: var(--pine-color-red-100);
   --pine-color-danger-hover: var(--pine-color-red-700);
-  --pine-color-focus-ring: var(--pine-color-purple-300);
+  --pine-color-focus-ring: var(--pine-color-grey-300);
   --pine-color-focus-ring-danger: var(--pine-color-red-300);
   --pine-color-info: var(--pine-color-blue-500);
   --pine-color-info-disabled: var(--pine-color-blue-100);
@@ -220,7 +220,7 @@
   --pine-color-danger: var(--pine-color-red-600);
   --pine-color-danger-disabled: var(--pine-color-red-100);
   --pine-color-danger-hover: var(--pine-color-red-700);
-  --pine-color-focus-ring: var(--pine-color-purple-300);
+  --pine-color-focus-ring: var(--pine-color-grey-300);
   --pine-color-focus-ring-danger: var(--pine-color-red-300);
   --pine-color-info: var(--pine-color-blue-500);
   --pine-color-info-disabled: var(--pine-color-blue-100);

--- a/packages/styles/_generated/kajabi_products/kajabi_products.scss
+++ b/packages/styles/_generated/kajabi_products/kajabi_products.scss
@@ -529,7 +529,7 @@
   --pine-color-danger: var(--pine-color-red-600);
   --pine-color-danger-disabled: var(--pine-color-red-100);
   --pine-color-danger-hover: var(--pine-color-red-700);
-  --pine-color-focus-ring: var(--pine-color-grey-400);
+  --pine-color-focus-ring: var(--pine-color-grey-500);
   --pine-color-focus-ring-danger: var(--pine-color-red-300);
   --pine-color-info: var(--pine-color-blue-500);
   --pine-color-info-disabled: var(--pine-color-blue-100);

--- a/packages/styles/_generated/kajabi_products/kajabi_products.scss
+++ b/packages/styles/_generated/kajabi_products/kajabi_products.scss
@@ -246,7 +246,7 @@
   --pine-color-danger: var(--pine-color-red-600);
   --pine-color-danger-disabled: var(--pine-color-red-100);
   --pine-color-danger-hover: var(--pine-color-red-700);
-  --pine-color-focus-ring: var(--pine-color-purple-300);
+  --pine-color-focus-ring: var(--pine-color-grey-300);
   --pine-color-focus-ring-danger: var(--pine-color-red-300);
   --pine-color-info: var(--pine-color-blue-500);
   --pine-color-info-disabled: var(--pine-color-blue-100);
@@ -529,7 +529,7 @@
   --pine-color-danger: var(--pine-color-red-600);
   --pine-color-danger-disabled: var(--pine-color-red-100);
   --pine-color-danger-hover: var(--pine-color-red-700);
-  --pine-color-focus-ring: var(--pine-color-purple-300);
+  --pine-color-focus-ring: var(--pine-color-grey-300);
   --pine-color-focus-ring-danger: var(--pine-color-red-300);
   --pine-color-info: var(--pine-color-blue-500);
   --pine-color-info-disabled: var(--pine-color-blue-100);

--- a/packages/styles/_generated/kajabi_products/kajabi_products.scss
+++ b/packages/styles/_generated/kajabi_products/kajabi_products.scss
@@ -246,7 +246,7 @@
   --pine-color-danger: var(--pine-color-red-600);
   --pine-color-danger-disabled: var(--pine-color-red-100);
   --pine-color-danger-hover: var(--pine-color-red-700);
-  --pine-color-focus-ring: var(--pine-color-grey-500);
+  --pine-color-focus-ring: var(--pine-color-grey-400);
   --pine-color-focus-ring-danger: var(--pine-color-red-300);
   --pine-color-info: var(--pine-color-blue-500);
   --pine-color-info-disabled: var(--pine-color-blue-100);
@@ -529,7 +529,7 @@
   --pine-color-danger: var(--pine-color-red-600);
   --pine-color-danger-disabled: var(--pine-color-red-100);
   --pine-color-danger-hover: var(--pine-color-red-700);
-  --pine-color-focus-ring: var(--pine-color-grey-300);
+  --pine-color-focus-ring: var(--pine-color-grey-400);
   --pine-color-focus-ring-danger: var(--pine-color-red-300);
   --pine-color-info: var(--pine-color-blue-500);
   --pine-color-info-disabled: var(--pine-color-blue-100);

--- a/packages/styles/_generated/kajabi_products/kajabi_products.scss
+++ b/packages/styles/_generated/kajabi_products/kajabi_products.scss
@@ -246,7 +246,7 @@
   --pine-color-danger: var(--pine-color-red-600);
   --pine-color-danger-disabled: var(--pine-color-red-100);
   --pine-color-danger-hover: var(--pine-color-red-700);
-  --pine-color-focus-ring: var(--pine-color-grey-300);
+  --pine-color-focus-ring: var(--pine-color-grey-600);
   --pine-color-focus-ring-danger: var(--pine-color-red-300);
   --pine-color-info: var(--pine-color-blue-500);
   --pine-color-info-disabled: var(--pine-color-blue-100);

--- a/packages/styles/_generated/kajabi_products/kajabi_products.scss
+++ b/packages/styles/_generated/kajabi_products/kajabi_products.scss
@@ -246,7 +246,7 @@
   --pine-color-danger: var(--pine-color-red-600);
   --pine-color-danger-disabled: var(--pine-color-red-100);
   --pine-color-danger-hover: var(--pine-color-red-700);
-  --pine-color-focus-ring: var(--pine-color-grey-600);
+  --pine-color-focus-ring: var(--pine-color-grey-500);
   --pine-color-focus-ring-danger: var(--pine-color-red-300);
   --pine-color-info: var(--pine-color-blue-500);
   --pine-color-info-disabled: var(--pine-color-blue-100);

--- a/packages/styles/_generated/pine/pine.scss
+++ b/packages/styles/_generated/pine/pine.scss
@@ -212,7 +212,7 @@
   --pine-color-danger: var(--pine-color-red-600);
   --pine-color-danger-disabled: var(--pine-color-red-100);
   --pine-color-danger-hover: var(--pine-color-red-700);
-  --pine-color-focus-ring: var(--pine-color-grey-300);
+  --pine-color-focus-ring: var(--pine-color-grey-600);
   --pine-color-focus-ring-danger: var(--pine-color-red-300);
   --pine-color-info: var(--pine-color-blue-500);
   --pine-color-info-disabled: var(--pine-color-blue-100);

--- a/packages/styles/_generated/pine/pine.scss
+++ b/packages/styles/_generated/pine/pine.scss
@@ -212,7 +212,7 @@
   --pine-color-danger: var(--pine-color-red-600);
   --pine-color-danger-disabled: var(--pine-color-red-100);
   --pine-color-danger-hover: var(--pine-color-red-700);
-  --pine-color-focus-ring: var(--pine-color-purple-300);
+  --pine-color-focus-ring: var(--pine-color-grey-300);
   --pine-color-focus-ring-danger: var(--pine-color-red-300);
   --pine-color-info: var(--pine-color-blue-500);
   --pine-color-info-disabled: var(--pine-color-blue-100);
@@ -495,7 +495,7 @@
   --pine-color-danger: var(--pine-color-red-600);
   --pine-color-danger-disabled: var(--pine-color-red-100);
   --pine-color-danger-hover: var(--pine-color-red-700);
-  --pine-color-focus-ring: var(--pine-color-purple-300);
+  --pine-color-focus-ring: var(--pine-color-grey-300);
   --pine-color-focus-ring-danger: var(--pine-color-red-300);
   --pine-color-info: var(--pine-color-blue-500);
   --pine-color-info-disabled: var(--pine-color-blue-100);

--- a/packages/styles/_generated/pine/pine.scss
+++ b/packages/styles/_generated/pine/pine.scss
@@ -212,7 +212,7 @@
   --pine-color-danger: var(--pine-color-red-600);
   --pine-color-danger-disabled: var(--pine-color-red-100);
   --pine-color-danger-hover: var(--pine-color-red-700);
-  --pine-color-focus-ring: var(--pine-color-grey-500);
+  --pine-color-focus-ring: var(--pine-color-grey-400);
   --pine-color-focus-ring-danger: var(--pine-color-red-300);
   --pine-color-info: var(--pine-color-blue-500);
   --pine-color-info-disabled: var(--pine-color-blue-100);
@@ -495,7 +495,7 @@
   --pine-color-danger: var(--pine-color-red-600);
   --pine-color-danger-disabled: var(--pine-color-red-100);
   --pine-color-danger-hover: var(--pine-color-red-700);
-  --pine-color-focus-ring: var(--pine-color-grey-300);
+  --pine-color-focus-ring: var(--pine-color-grey-400);
   --pine-color-focus-ring-danger: var(--pine-color-red-300);
   --pine-color-info: var(--pine-color-blue-500);
   --pine-color-info-disabled: var(--pine-color-blue-100);

--- a/packages/styles/_generated/pine/pine.scss
+++ b/packages/styles/_generated/pine/pine.scss
@@ -212,7 +212,7 @@
   --pine-color-danger: var(--pine-color-red-600);
   --pine-color-danger-disabled: var(--pine-color-red-100);
   --pine-color-danger-hover: var(--pine-color-red-700);
-  --pine-color-focus-ring: var(--pine-color-grey-600);
+  --pine-color-focus-ring: var(--pine-color-grey-500);
   --pine-color-focus-ring-danger: var(--pine-color-red-300);
   --pine-color-info: var(--pine-color-blue-500);
   --pine-color-info-disabled: var(--pine-color-blue-100);

--- a/packages/styles/_generated/pine/pine.scss
+++ b/packages/styles/_generated/pine/pine.scss
@@ -495,7 +495,7 @@
   --pine-color-danger: var(--pine-color-red-600);
   --pine-color-danger-disabled: var(--pine-color-red-100);
   --pine-color-danger-hover: var(--pine-color-red-700);
-  --pine-color-focus-ring: var(--pine-color-grey-400);
+  --pine-color-focus-ring: var(--pine-color-grey-500);
   --pine-color-focus-ring-danger: var(--pine-color-red-300);
   --pine-color-info: var(--pine-color-blue-500);
   --pine-color-info-disabled: var(--pine-color-blue-100);

--- a/packages/styles/src/tokens/semantic/dark.json
+++ b/packages/styles/src/tokens/semantic/dark.json
@@ -153,7 +153,7 @@
     },
     "focus-ring": {
       "@": {
-        "value": "{color.grey.300}",
+        "value": "{color.grey.400}",
         "type": "color"
       },
       "danger": {

--- a/packages/styles/src/tokens/semantic/dark.json
+++ b/packages/styles/src/tokens/semantic/dark.json
@@ -153,7 +153,7 @@
     },
     "focus-ring": {
       "@": {
-        "value": "{color.purple.300}",
+        "value": "{color.grey.300}",
         "type": "color"
       },
       "danger": {

--- a/packages/styles/src/tokens/semantic/dark.json
+++ b/packages/styles/src/tokens/semantic/dark.json
@@ -153,7 +153,7 @@
     },
     "focus-ring": {
       "@": {
-        "value": "{color.grey.400}",
+        "value": "{color.grey.500}",
         "type": "color"
       },
       "danger": {

--- a/packages/styles/src/tokens/semantic/light.json
+++ b/packages/styles/src/tokens/semantic/light.json
@@ -187,7 +187,7 @@
     },
     "focus-ring": {
       "@": {
-        "value": "{color.purple.300}",
+        "value": "{color.grey.300}",
         "type": "color"
       },
       "danger": {

--- a/packages/styles/src/tokens/semantic/light.json
+++ b/packages/styles/src/tokens/semantic/light.json
@@ -187,7 +187,7 @@
     },
     "focus-ring": {
       "@": {
-        "value": "{color.grey.600}",
+        "value": "{color.grey.500}",
         "type": "color"
       },
       "danger": {

--- a/packages/styles/src/tokens/semantic/light.json
+++ b/packages/styles/src/tokens/semantic/light.json
@@ -187,7 +187,7 @@
     },
     "focus-ring": {
       "@": {
-        "value": "{color.grey.300}",
+        "value": "{color.grey.600}",
         "type": "color"
       },
       "danger": {

--- a/packages/styles/src/tokens/semantic/light.json
+++ b/packages/styles/src/tokens/semantic/light.json
@@ -187,7 +187,7 @@
     },
     "focus-ring": {
       "@": {
-        "value": "{color.grey.500}",
+        "value": "{color.grey.400}",
         "type": "color"
       },
       "danger": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Repoints the Pine `focus-ring` semantic color token from purple to a neutral grey. It remains a proper **semantic token** defined per-mode in `semantic/light.json` and `semantic/dark.json`, with mode-specific values:

| Mode | Token value | Hex |
| --- | --- | --- |
| Light (`semantic/light.json`) | `{color.grey.400}` | `#BBBAB9` |
| Dark (`semantic/dark.json`) | `{color.grey.500}` | `#9B9A98` |

Only the default (non-danger) ring changes; `focus-ring.danger` stays red.

## Before / After (light + dark)

The "before" was purple; the "after" is neutral grey. Screenshots rendered from the actual emitted token values (2px solid ring) via headless Chrome.

| Light mode (`grey.400` `#BBBAB9`) | Dark mode (`grey.500` `#9B9A98`) |
| --- | --- |
| [Focus ring light mode - grey.400](https://cursor.com/agents/bc-019f7b9c-c9fa-77eb-a776-81318d4e705f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ffocus-ring-light.png) | [Focus ring dark mode - grey.500](https://cursor.com/agents/bc-019f7b9c-c9fa-77eb-a776-81318d4e705f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ffocus-ring-dark.png) |

Previous purple state for reference:

| Before (`purple.300` `#A4ACFD`, light mode) |
| --- |
| [Focus ring before - purple](https://cursor.com/agents/bc-019f7b9c-c9fa-77eb-a776-81318d4e705f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ffocus-ring-before.png) |

## Changes

- `packages/styles/src/tokens/semantic/light.json` — `color.focus-ring.@` → `{color.grey.400}`
- `packages/styles/src/tokens/semantic/dark.json` — `color.focus-ring.@` → `{color.grey.500}`
- Regenerated (`npm run generate`):
  - `_generated/base/_semantic.scss`
  - `_generated/pine/pine.scss`
  - `_generated/kajabi_products/kajabi_products.scss`

Emitted result:

```scss
:root { --pine-color-focus-ring: var(--pine-color-grey-400); }
[data-theme="dark"] { --pine-color-focus-ring: var(--pine-color-grey-500); }
```

## Out of scope

The Kajabi-specific `[data-theme="site"]` override in `src/lib/transform/index.js` still falls back to `--pine-color-purple-300` when `--kj-brand-primary` is unset. This is a brand-accent fallback distinct from the Pine focus-ring token, so it is intentionally left unchanged.

## Versioning note (visually significant)

Per [VERSIONING.md](VERSIONING.md) this is a value-only repoint of an existing token (meaning unchanged) = **patch**, but it's a **visually significant hue shift** (purple → grey) that affects every focused element in downstream apps. Consumers should QA focus states before upgrading.

## Verification

- `npm run test` — 6/6 passing (token invariants)
- `npm run lint` — 0 errors (pre-existing unused-var warnings only)
- Confirmed `--pine-color-focus-ring` resolves to grey-400 in the light block and grey-500 in the dark block across all generated brand files.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7b9c-c9fa-77eb-a776-81318d4e705f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7b9c-c9fa-77eb-a776-81318d4e705f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

